### PR TITLE
Target main branch, ignore secret+text files in CI

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -1,6 +1,13 @@
 name: Run Tests
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches: [ "main" ]
+    paths-ignore: [ ".*", "**/.*", "**.md", "**.txt" ]
+  pull_request:
+    branches: [ "main" ]
+    paths-ignore: [ ".*", "**/.*", "**.md", "**.txt" ]
+  workflow_dispatch:
 
 jobs:
   build-test:


### PR DESCRIPTION
The previous settings of the "Run Tests" GitHub Actions configuration triggered builds and test runs on _every_ push on _every_ branch. This should limit builds only to pushes on pull requests and the `main` branch.

Also, it turns out that GitHub Actions can ignore commits that affect only secret files or test files. So I can make README.md changes, for example, without kicking off an unnecessary build. Pretty cool!