### PR TITLE
Run Tests on all pushes except wip/** branch, PRs

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -2,10 +2,9 @@ name: Run Tests
 
 on:
   push:
-    branches: [ "main" ]
+    branches-ignore: [ "wip/**" ]
     paths-ignore: [ ".*", "**/.*", "**.md", "**.txt" ]
   pull_request:
-    branches: [ "main" ]
     paths-ignore: [ ".*", "**/.*", "**.md", "**.txt" ]
   workflow_dispatch:
 


### PR DESCRIPTION
I could not get PR #3 to run the Run Tests action after updating the branch protection rule, force-pushing, or closing/reopening the PR. I think it's because the updates in PR #2 were too restrictive.

Once I commit this, I'll try to trigger PR #3 again.