### PR TITLE
Try refining Run Tests GitHub Action again

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -1,10 +1,21 @@
 name: Run Tests
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches: [ "main" ]
+    paths-ignore: [ ".*", "**/.*", "**.md", "**.txt" ]
+  pull_request:
+    branches: [ "main" ]
+    paths-ignore: [ ".*", "**/.*", "**.md", "**.txt" ]
+    types: [ opened, synchronize, edited, reopened, closed ]
+  workflow_dispatch:
 
 jobs:
   build-test:
     name: "Run Tests"
+    if: >-
+      github.event_name == 'push' ||
+      github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
PR #7 triggered the Run Tests action again, but did so multiple times.

I want all pushes to `main` to trigger builds, as well as updates to pull requests, but not pushes to other branches. And I want each action to run only once per PR.

This is an attempt to get the right thing to happen based on advice from:

- https://stackoverflow.com/a/65096459
- https://github.com/orgs/community/discussions/26276#discussioncomment-3251140