### PR TITLE
Fix Run Tests conditional for open pull requests

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches: [ "main" ]
     paths-ignore: [ ".*", "**/.*", "**.md", "**.txt" ]
-    types: [ opened, synchronize, edited, reopened, closed ]
+    types: [ opened, synchronize, reopened, closed ]
   workflow_dispatch:
 
 jobs:
@@ -15,6 +15,7 @@ jobs:
     name: "Run Tests"
     if: >-
       github.event_name == 'push' ||
+      github.event.pull_request.state == 'open' ||
       github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The Run Tests `if:` conditional from #8 didn't allow #9 to run, because it excluded still opened pull requests. So now it should run:

- On 'push' events on `main`
- On any events from open 'pull_request' against `main` (specifically opened, synchronize, and reopened)
- On any closed 'pull_request' event resulting in a merge into `main`

I also realized that including the "edited" action type didn't actually make a lot of sense for my purposes.

For reference:

- https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
- https://docs.github.com/en/webhooks/webhook-events-and-payloads#pull_request