### PR TITLE
Remove Run Tests conditional, pull_request.types

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -7,16 +7,11 @@ on:
   pull_request:
     branches: [ "main" ]
     paths-ignore: [ ".*", "**/.*", "**.md", "**.txt" ]
-    types: [ opened, synchronize, reopened, closed ]
   workflow_dispatch:
 
 jobs:
   build-test:
     name: "Run Tests"
-    if: >-
-      github.event_name == 'push' ||
-      github.event.pull_request.state == 'open' ||
-      github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Essentially restores commit d69488808b23e19f5caf2b2f3ac9df3fcad592b6.

Still having trouble getting #9 to run. If this doesn't work, I'll try removing the paths-ignore properties again. I really don't want to, though.

Also removed pull_request.types, as I'm not sure how necessary it should really be.