### PR TITLE
Remove .* and **/.* from Run Tests paths-ignore

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -3,10 +3,10 @@ name: Run Tests
 on:
   push:
     branches: [ "main" ]
-    paths-ignore: [ ".*", "**/.*", "**.md", "**.txt" ]
+    paths-ignore: [ "**.md", "**.txt" ]
   pull_request:
     branches: [ "main" ]
-    paths-ignore: [ ".*", "**/.*", "**.md", "**.txt" ]
+    paths-ignore: [ "**.md", "**.txt" ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Still not getting #9 to trigger status checks even after merging #11. Perhaps .* or **/.* is inadvertently ignoring too many files somehow.