### PR TITLE
Bump io.smallrye:jandex to 3.1.6, set warning.mode=all in gradle.props and to fail in CI 

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -39,17 +39,17 @@ jobs:
         uses: gradle/gradle-build-action@v2
 
       - name: Install Node packages
-        run: ./gradlew pnpmInstall
+        run: ./gradlew --warning-mode=fail pnpmInstall
 
       - name: Build and test
-        run: ./gradlew build
+        run: ./gradlew --warning-mode=fail build
 
       - name: Merge test reports
-        run: ./gradlew merge-test-reports
+        run: ./gradlew --warning-mode=fail merge-test-reports
         if: always()
 
       - name: Generate coverage report
-        run: ./gradlew jacocoXmlTestReport
+        run: ./gradlew --warning-mode=fail jacocoXmlTestReport
         if: always()
 
       # Per the advice from:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.caching=true
-org.gradle.warning.mode=fail
+org.gradle.warning.mode=all

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ hamcrestVer = "2.2"
 antJunitVer = "1.10.14"
 seleniumVer = "4.15.0"
 weldVer = "5.1.2.Final"
-jandexVer = "3.1.5"
+jandexVer = "3.1.6"
 jacksonVer = "2.16.0"
 
 [libraries.servlet]


### PR DESCRIPTION
A couple of small touch-up tasks. But specifically regarding `org.gradle.warning.mode=all`:

Having org.gradle.warning.mode=fail in gradle.properties was causing the Visual Studio Code Gradle extension to fail with:

```text
  [info] The Project.getConvention() method has been deprecated. This is
  scheduled to be removed in Gradle 9.0. Consult the upgrading guide for
  further information:
  https://docs.gradle.org/8.4/userguide/upgrading_version_8.html#deprecated_access_to_conventions

  The org.gradle.api.plugins.Convention type has been deprecated. This
  is scheduled to be removed in Gradle 9.0. Consult the upgrading guide
  for further information:
  https://docs.gradle.org/8.4/userguide/upgrading_version_8.html#deprecated_access_to_conventions
```

Also, running `./gradlew dependencyUpdates` without `-q` fails with:

```text
  The compileClasspathCopy configuration has been deprecated for
  dependency declaration. This will fail with an error in Gradle 9.0.
  Please use another configuration instead. For more information, please
  refer to
  https://docs.gradle.org/8.4/userguide/declaring_dependencies.html#sec:deprecated-configurations
  in the Gradle documentation.
```

The same warning repeats for:

- compileClasspathCopy2
- runtimeClasspathCopy
- runtimeClasspathCopy2
- testCompileClasspathCopy
- testCompileClasspathCopy2
- testRuntimeClasspathCopy
- testRuntimeClasspathCopy2

Both of these invocations terminate with:

```text
  FAILURE: Build failed with an exception.

  * What went wrong:
  Deprecated Gradle features were used in this build, making it
  incompatible with Gradle 9.0
```

As much as I wish I could keep it set to "fail," these instances are annoying and I can't do anything else directly.

To keep the CI build clean, however, I've added the `--warning-mode=fail` flag to all `./gradlew` invocations in run_tests.yml.