### PR TITLE
Inject Servlet in getAddEndpointReturnsPlaceholder, implement Handlebar template helper support

### DIFF
--- a/strcalc/src/main/frontend/components/helpers.js
+++ b/strcalc/src/main/frontend/components/helpers.js
@@ -1,0 +1,18 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+export default function(Handlebars) {
+  // Adapted from: https://handlebarsjs.com/guide/expressions.html#helpers
+  Handlebars.registerHelper('link', function(text, options) {
+    const attrs = Object.keys(options.hash).map(key => {
+      return `${Handlebars.escapeExpression(key)}=` +
+        `"${Handlebars.escapeExpression(options.hash[key])}"`
+    })
+    return new Handlebars.SafeString(
+      `<a ${attrs.join(' ')}>${Handlebars.escapeExpression(text)}</a>`
+    )
+  })
+}

--- a/strcalc/src/main/frontend/components/placeholder.hbs
+++ b/strcalc/src/main/frontend/components/placeholder.hbs
@@ -1,1 +1,6 @@
-<p class="placeholder">{{message}}</p>
+{{!--
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+--}}
+<p class="placeholder">{{link message href=url}}</p>

--- a/strcalc/src/main/frontend/components/placeholder.js
+++ b/strcalc/src/main/frontend/components/placeholder.js
@@ -14,7 +14,9 @@ export default class Placeholder {
   }
 
   init() {
-    const d = { message: 'Hello, World!' }
-    this.#document.querySelector('#app').innerHTML = Template(d)
+    this.#document.querySelector('#app').innerHTML = Template({
+      message: 'Hello, World!',
+      url: 'https://en.wikipedia.org/wiki/%22Hello,_World!%22_program'
+    })
   }
 }

--- a/strcalc/src/main/frontend/vite.config.js
+++ b/strcalc/src/main/frontend/vite.config.js
@@ -11,7 +11,9 @@ export function buildDir(relativePath) {
 
 export default defineConfig({
   base: '/strcalc',
-  plugins: [ handlebarsPrecompiler() ],
+  plugins: [
+    handlebarsPrecompiler({ helpers: ['components/helpers.js'] })
+  ],
   build: {
     outDir: buildDir('webapp')
   },

--- a/strcalc/src/test/java/com/mike_bland/training/testing/stringcalculator/ServletContractTest.java
+++ b/strcalc/src/test/java/com/mike_bland/training/testing/stringcalculator/ServletContractTest.java
@@ -135,7 +135,15 @@ class ServletContractTest {
     @MediumCoverageTest
     void getAddEndpointReturnsPlaceholderString() throws Exception {
         var req = newRequestBuilder("/add").GET().build();
-        tomcat.start();
+        // Inject a Lambda as a StringCalculator test double which won't get
+        // called. In this case, this test double is known as a "dummy", since
+        // it's required for the call but isn't used. In other test methods
+        // below that actually call the Lambda, we call those test doubles
+        // "stubs".
+        //
+        // See the comments for those other test methods below for more
+        // background on using test doubles in general.
+        tomcat.start(new Servlet(numbers -> 0));
 
         var resp = sendRequest(req);
 

--- a/strcalc/src/test/java/com/mike_bland/training/testing/stringcalculator/ServletContractTest.java
+++ b/strcalc/src/test/java/com/mike_bland/training/testing/stringcalculator/ServletContractTest.java
@@ -135,15 +135,7 @@ class ServletContractTest {
     @MediumCoverageTest
     void getAddEndpointReturnsPlaceholderString() throws Exception {
         var req = newRequestBuilder("/add").GET().build();
-        // Inject a Lambda as a StringCalculator test double which won't get
-        // called. In this case, this test double is known as a "dummy", since
-        // it's required for the call but isn't used. In other test methods
-        // below that actually call the Lambda, we call those test doubles
-        // "stubs".
-        //
-        // See the comments for those other test methods below for more
-        // background on using test doubles in general.
-        tomcat.start(new Servlet(numbers -> 0));
+        tomcat.start();
 
         var resp = sendRequest(req);
 


### PR DESCRIPTION
The first commit is a minor test refactor:

**[Inject Servlet in getAddEndpointReturnsPlaceholder](https://github.com/mbland/tomcat-servlet-testing-example/commit/9ea01fcd43d9dd3a8a641dfe01b47e5f9662f96d)**
There's no reason this test needs to depend on the slower, more expensive no-arg version of TestTomcat.setup().

Includes a comment explaining why this Lambda serving as a StringCalculator test double is a "dummy" as opposed to a "stub".

---

The second commit provides the bulk of the change:

**[Implement Handlebar template helper support](https://github.com/mbland/tomcat-servlet-testing-example/commit/0ac3d857c78920bdc8dbc159be357eac55446872)**
Enables more complex Handlebars template behavior by automatically registering Handlebars helper functions:

- https://handlebarsjs.com/guide/#custom-helpers
- https://handlebarsjs.com/guide/expressions.html#helpers

Adapted from parts of:

- https://github.com/mixmaxhq/rollup-plugin-handlebars-plus/blob/master/src/index.js