### PR TITLE
Handlebars and test touch ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -739,18 +739,6 @@ plugin:
 - Configure the selected plugin to process the downloaded
 `jacocoXmlTestReport.xml` file.
 
-## Adding large tests
-
-Coming soon...
-
-TODO(mbland): Document how the following are configured:
-
-- [Gradle WAR Plugin][] - now writes to/includes files from `strcalc/build/webapp`
-- [Selenium WebDriver][]
-- [TestTomcat](./strcalc/src/test/java/com/mike_bland/training/testing/utils/TestTomcat.java)
-  (for medium tests)
-- [node-gradle/gradle-node-plugin][]
-
 ## Setup frontend JavaScript environment
 
 [Node.js][] is a JavaScript runtime environment. [pnpm][] is a Node.js package
@@ -784,6 +772,20 @@ Code support:
 - [ESLint extension for Visual Studio Code][]
 - [Vite IntelliJ plugin][]
 - [Vite extension for Visual Studio Code][]
+
+## Adding large tests
+
+Coming soon...
+
+TODO(mbland): Document how the following are configured:
+
+- [Gradle WAR Plugin][] - now writes to/includes files from `strcalc/build/webapp`
+- [Selenium WebDriver][] - include references to:
+  - [Selenium: Design patterns and development strategies][]
+- [TestTomcat](./strcalc/src/test/java/com/mike_bland/training/testing/utils/TestTomcat.java)
+  (for medium tests)
+- [node-gradle/gradle-node-plugin][]
+
 
 ## Implementing core logic using Test Driven Development and unit tests
 
@@ -890,3 +892,4 @@ Coming soon...
 [ESLint extension for Visual Studio Code]: https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint
 [Vite IntelliJ plugin]: https://plugins.jetbrains.com/plugin/20011-vite
 [Vite extension for Visual Studio Code]: https://marketplace.visualstudio.com/items?itemName=antfu.vite
+[Selenium: Design patterns and development strategies]: https://www.selenium.dev/documentation/test_practices/design_strategies/

--- a/strcalc/src/main/frontend/main.test.js
+++ b/strcalc/src/main/frontend/main.test.js
@@ -12,9 +12,10 @@ describe('String Calculator UI', () => {
     test('contains the "Hello, World!" placeholder', async () => {
       let { document } = await loader.load('index.html')
 
-      let e = document.querySelector('#app .placeholder')
+      let e = document.querySelector('#app .placeholder a')
 
       expect(e.textContent).toContain('Hello, World!')
+      expect(e.href).toContain('%22Hello,_World!%22')
     })
   })
 })

--- a/strcalc/src/main/frontend/rollup-plugin-handlebars-precompile.js
+++ b/strcalc/src/main/frontend/rollup-plugin-handlebars-precompile.js
@@ -47,8 +47,8 @@ const IMPORT_HANDLEBARS = `import Handlebars from '${HANDLEBARS_PATH}'`
 function helpersModule(helpers) {
   return [
     IMPORT_HANDLEBARS,
-    ...helpers.map((h, i) => `import helpers${i} from './${h}'`),
-    ...helpers.map((_, i) => `helpers${i}(Handlebars)`)
+    ...helpers.map((h, i) => `import registerHelpers${i} from './${h}'`),
+    ...helpers.map((_, i) => `registerHelpers${i}(Handlebars)`)
   ].join('\n')
 }
 
@@ -66,15 +66,17 @@ export default function (options = {}) {
     options.exclude || DEFAULT_EXCLUDE
   )
   const helpers = options.helpers || []
-  const isThisPlugin = id => id === PLUGIN_ID && helpers.length
+  const shouldEmitHelpersModule = id => id === PLUGIN_ID && helpers.length
   const imports = helpers.length ? [`import '${PLUGIN_ID}'`] : []
 
   return {
     name: PLUGIN_NAME,
 
-    resolveId(id) { if (isThisPlugin(id)) return id },
+    resolveId(id) { if (shouldEmitHelpersModule(id)) return id },
 
-    load(id) { if (isThisPlugin(id)) return helpersModule(helpers) },
+    load(id) {
+      if (shouldEmitHelpersModule(id)) return helpersModule(helpers)
+    },
 
     transform(code, id) {
       if (isTemplate(id)) return {

--- a/strcalc/src/main/frontend/rollup-plugin-handlebars-precompile.js
+++ b/strcalc/src/main/frontend/rollup-plugin-handlebars-precompile.js
@@ -52,7 +52,10 @@ function helpersModule(helpers) {
   ].join('\n')
 }
 
-function compiledModule(compiled, imports) {
+function compiledModule(code, options, helpers) {
+  const compiled = Handlebars.precompile(code, options)
+  let imports = helpers.length ? [`import '${PLUGIN_ID}'`] : []
+
   return [
     IMPORT_HANDLEBARS,
     ...imports,
@@ -67,7 +70,6 @@ export default function (options = {}) {
   )
   const helpers = options.helpers || []
   const shouldEmitHelpersModule = id => id === PLUGIN_ID && helpers.length
-  const imports = helpers.length ? [`import '${PLUGIN_ID}'`] : []
 
   return {
     name: PLUGIN_NAME,
@@ -80,7 +82,7 @@ export default function (options = {}) {
 
     transform(code, id) {
       if (isTemplate(id)) return {
-        code: compiledModule(Handlebars.precompile(code, options), imports)
+        code: compiledModule(code, options, helpers)
       }
     }
   }

--- a/strcalc/src/test/java/com/mike_bland/training/testing/stringcalculator/ServletContractTest.java
+++ b/strcalc/src/test/java/com/mike_bland/training/testing/stringcalculator/ServletContractTest.java
@@ -135,7 +135,11 @@ class ServletContractTest {
     @MediumCoverageTest
     void getAddEndpointReturnsPlaceholderString() throws Exception {
         var req = newRequestBuilder("/add").GET().build();
-        tomcat.start();
+        // We're covering the zero argument Servlet constructor while injecting
+        // a Servlet directly into the TestTomcat, which will leave the
+        // Servlet's calculator member uninitialized. In this case it's OK,
+        // since we aren't exercising a code path that uses it.
+        tomcat.start(new Servlet());
 
         var resp = sendRequest(req);
 

--- a/strcalc/src/test/java/com/mike_bland/training/testing/stringcalculator/WebApplicationTest.java
+++ b/strcalc/src/test/java/com/mike_bland/training/testing/stringcalculator/WebApplicationTest.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 import java.net.URI;
 import java.time.Duration;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class WebApplicationTest {
@@ -78,8 +80,12 @@ public class WebApplicationTest {
     void testPlaceholder() {
         driver.get(endpoint("/"));
 
-        WebElement body = driver.findElement(By.cssSelector("p.placeholder"));
+        WebElement elem = driver.findElement(By.cssSelector("p.placeholder a"));
 
-        assertEquals("Hello, World!", body.getText());
+        assertEquals("Hello, World!", elem.getText());
+        assertThat(
+                elem.getAttribute("href"),
+                containsString("%22Hello,_World!%22")
+        );
     }
 }


### PR DESCRIPTION
Another grab bag of small changes:

**[Rename Handlebars helper imports, helper predicate](https://github.com/mbland/tomcat-servlet-testing-example/commit/5e281d879444c6d963170dfa060a40b7d8db72a2)**

Small changes that improve understanding of what's happening.

---

**[Inject Servlet in getAddEndpointReturnsPlaceholder](https://github.com/mbland/tomcat-servlet-testing-example/commit/f96efebad7a982662930514ebc0ed8818d4aa086)** 

Reverts commit https://github.com/mbland/tomcat-servlet-testing-example/commit/e5f2a77ddc4e9e857b9eae99e0f0559c8555841a (sort of) back to commit https://github.com/mbland/tomcat-servlet-testing-example/commit/9ea01fcd43d9dd3a8a641dfe01b47e5f9662f96d (sort of).

It occurred to me that we _could_ still call the zero-arg Servlet constructor and inject it. This time, the comment reflects the fact that Servlet.calculator will remain uninitialized as a result, but that it's OK in this specific test case.

---

**[Pass Handlebars code, helpers into compiledModule](https://github.com/mbland/tomcat-servlet-testing-example/commit/312e956a472376eb7ab1d3b937d6bc979b261190)**

This is in preparation for having compiledModule() do more work to support partial templates. This will require adding a Handlebars.Visitor to collect partials from the code to import, and registering the code as a partial if need be. See:

- https://github.com/mixmaxhq/rollup-plugin-handlebars-plus/blob/master/src/index.js
- https://github.com/mixmaxhq/rollup-plugin-handlebars-plus/blob/master/src/ImportScanner.js
- https://github.com/wycats/handlebars.js/blob/master/docs/compiler-api.md

---

**[Validate "Hello, World!" URL in frontend test](https://github.com/mbland/tomcat-servlet-testing-example/commit/cdfbe90975e1ae1a0aacf4b7a8b969972ede81f6)**

Should've been part of commit https://github.com/mbland/tomcat-servlet-testing-example/commit/0ac3d857c78920bdc8dbc159be357eac55446872.

Also, right now the main.test.js (using Vitest) and WebApplicationTest.java (using Selenium WebDriver) are essentially mirroring one another. The difference being that:

- main.test.js is working directly and only with the DOM
- WebApplicationTest.java is opening a browser and sending a request to Tomcat, running in Docker, which dispatches the request to the Servlet from strcalc.war

The former is obviously much faster, the latter is more thorough, and both play a critical role in the Test Pyramid based strategy.

I may want to keep these tests and call this out in the comments/docs/lesson. But I may also want to apply either or both of the Page Object or Bot Patterns at some point, as advised by:

- https://www.selenium.dev/documentation/test_practices/design_strategies/