### PR TITLE
Refactor Handlebars precompiler as PluginImpl

### DIFF
--- a/strcalc/src/main/frontend/rollup-plugin-handlebars-precompile.js
+++ b/strcalc/src/main/frontend/rollup-plugin-handlebars-precompile.js
@@ -44,46 +44,56 @@ const PLUGIN_ID = `\0${PLUGIN_NAME}`
 const HANDLEBARS_PATH = 'handlebars/lib/handlebars.runtime'
 const IMPORT_HANDLEBARS = `import Handlebars from '${HANDLEBARS_PATH}'`
 
-function helpersModule(helpers) {
-  return [
-    IMPORT_HANDLEBARS,
-    ...helpers.map((h, i) => `import registerHelpers${i} from './${h}'`),
-    ...helpers.map((_, i) => `registerHelpers${i}(Handlebars)`)
-  ].join('\n')
+class PluginImpl {
+  #options
+  #helpers
+  #isTemplate
+
+  constructor(options = {}) {
+    this.#options = options
+    this.#helpers = options.helpers || []
+    this.#isTemplate = createFilter(
+      options.include || DEFAULT_INCLUDE,
+      options.exclude || DEFAULT_EXCLUDE
+    )
+  }
+
+  shouldEmitHelpersModule(id) {
+    return id === PLUGIN_ID && this.#helpers.length
+  }
+
+  helpersModule() {
+    const helpers = this.#helpers
+    return [
+      IMPORT_HANDLEBARS,
+      ...helpers.map((h, i) => `import registerHelpers${i} from './${h}'`),
+      ...helpers.map((_, i) => `registerHelpers${i}(Handlebars)`)
+    ].join('\n')
+  }
+
+  isTemplate(id) { return this.#isTemplate(id) }
+
+  compiledModule(code) {
+    const precompiled = Handlebars.precompile(code, this.#options)
+    let imports = this.#helpers.length ? [`import '${PLUGIN_ID}'`] : []
+
+    return {
+      code: [
+        IMPORT_HANDLEBARS,
+        ...imports,
+        `export default Handlebars.template(${precompiled.toString()})`
+      ].join('\n')
+    }
+  }
 }
 
-function compiledModule(code, options, helpers) {
-  const compiled = Handlebars.precompile(code, options)
-  let imports = helpers.length ? [`import '${PLUGIN_ID}'`] : []
-
-  return [
-    IMPORT_HANDLEBARS,
-    ...imports,
-    `export default Handlebars.template(${compiled.toString()})`
-  ].join('\n')
-}
-
-export default function (options = {}) {
-  const isTemplate = createFilter(
-    options.include || DEFAULT_INCLUDE,
-    options.exclude || DEFAULT_EXCLUDE
-  )
-  const helpers = options.helpers || []
-  const shouldEmitHelpersModule = id => id === PLUGIN_ID && helpers.length
+export default function(options) {
+  const p = new PluginImpl(options)
 
   return {
     name: PLUGIN_NAME,
-
-    resolveId(id) { if (shouldEmitHelpersModule(id)) return id },
-
-    load(id) {
-      if (shouldEmitHelpersModule(id)) return helpersModule(helpers)
-    },
-
-    transform(code, id) {
-      if (isTemplate(id)) return {
-        code: compiledModule(code, options, helpers)
-      }
-    }
+    resolveId(id) { if (p.shouldEmitHelpersModule(id)) return id },
+    load(id) { if (p.shouldEmitHelpersModule(id)) return p.helpersModule() },
+    transform(code, id) { if (p.isTemplate(id)) return p.compiledModule(code) }
   }
 }


### PR DESCRIPTION
This is in preparation for supporting partial templates. As it became apparent that compiledModule() would need more information, it made sense to create a PluginImpl class, versus passing a bunch of arguments.

Though it's a little more code, I think what's happening inside the plugin is even more understandable now.