### PR TITLE
Support Handlebars partial templates

### DIFF
--- a/strcalc/src/main/frontend/components/_message-link.hbs
+++ b/strcalc/src/main/frontend/components/_message-link.hbs
@@ -3,7 +3,7 @@
   License, v. 2.0. If a copy of the MPL was not distributed with this
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-  This is an example of a Handlebars template that invokes a partial template
-  via '{{>'. See: https://handlebarsjs.com/guide/partials.html#basic-partials
+  This is an example of a Handlebars partial template that invokes a custom
+  helper. See: https://handlebarsjs.com/guide/expressions.html#helpers
 --}}
-<p class="placeholder">{{> message-link }}</p>
+{{link message href=url}}

--- a/strcalc/src/main/frontend/components/helpers.js
+++ b/strcalc/src/main/frontend/components/helpers.js
@@ -2,10 +2,12 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * This is an example of a custom Handlebars helper, adapted directly from:
+ * - https://handlebarsjs.com/guide/expressions.html#helpers
  */
 
 export default function(Handlebars) {
-  // Adapted from: https://handlebarsjs.com/guide/expressions.html#helpers
   Handlebars.registerHelper('link', function(text, options) {
     const attrs = Object.keys(options.hash).map(key => {
       return `${Handlebars.escapeExpression(key)}=` +

--- a/strcalc/src/main/frontend/components/placeholder.js
+++ b/strcalc/src/main/frontend/components/placeholder.js
@@ -2,6 +2,9 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * This is an example of a JavaScript class representing a web page component,
+ * implemented using a precompiled Handlebars template.
  */
 
 import Template from './placeholder.hbs'


### PR DESCRIPTION
Introduces the following default options for rollup-plugin-handlebars-precompile.js:

- partials: A file pattern identifying a partial template (after applying the include and exclude filter to identify all Handlebars template files). Defaults to matching any file name with a leading underscore (`**/_*`), for example 'foo/bar/_baz.hbs'.

- partialName: A function transforming a partial template file name into that partial's name as used in other templates. Defaults to the basename of the file stripped of its extension and any leading nonnumeric characters; e.g., 'foo/bar/_baz.hbs' would produce 'baz'.

- partialPath: A function to transform a partial's name and the path of the template using it into the import path of the partial template. Defaults to a path to a file in the same directory with a leading underscore and a file extension matching the importing template file. E.g., ('baz', 'foo/bar/quux.hbs') would become './_baz.hbs'.

These options make implementing a different partials schema possible, though hopefully the defaults encourage a reasonable schema to begin with.