### PR TITLE
Return compiled Handlebars string, no source maps

### DIFF
--- a/strcalc/src/main/frontend/rollup-plugin-handlebars-precompiler.js
+++ b/strcalc/src/main/frontend/rollup-plugin-handlebars-precompiler.js
@@ -90,6 +90,11 @@ class PluginImpl {
     this.#isPartial = createFilter(options.partials || DEFAULT_PARTIALS)
     this.#partialName = options.partialName || DEFAULT_PARTIAL_NAME
     this.#partialPath = options.partialPath || DEFAULT_PARTIAL_PATH
+
+    if (this.#options.compiler) {
+      delete this.#options.compiler.srcName
+      delete this.#options.compiler.destName
+    }
   }
 
   hasHelpers() { return this.#helpers.length }
@@ -112,16 +117,14 @@ class PluginImpl {
     const collector = new PartialCollector()
     collector.accept(ast)
 
-    return {
-      code: [
-        IMPORT_HANDLEBARS,
-        ...(this.hasHelpers() ? [ IMPORT_HELPERS ] : []),
-        ...collector.partials.map(p => `import '${this.#partialPath(p, id)}'`),
-        `const Template = Handlebars.template(${tmpl})`,
-        'export default Template',
-        ...(this.#isPartial(id) ? [ this.partialRegistration(id) ] : [])
-      ].join('\n')
-    }
+    return [
+      IMPORT_HANDLEBARS,
+      ...(this.hasHelpers() ? [ IMPORT_HELPERS ] : []),
+      ...collector.partials.map(p => `import '${this.#partialPath(p, id)}'`),
+      `const Template = Handlebars.template(${tmpl})`,
+      'export default Template',
+      ...(this.#isPartial(id) ? [ this.partialRegistration(id) ] : [])
+    ].join('\n')
   }
 
   partialRegistration(id) {


### PR DESCRIPTION
Originally the compiled template was wrapped as the `code:` attribute of a return object. However, the only use for returning an object is if we're returning Handlebars source maps.

Upon studying Handlebars source maps more closely, and experimenting locally by introducing errors here and there, they don't seem to be of much use. The existing error messages are fine, and I can't seem to find examples of Handebars source map usage online.

Now options.compiler.srcName and options.compiler.destName are explicitly undefined, to ensure Handlebars.precompile() only returns a string in PluginImpl.compile().

If one day a use case arises where it would make sense to support Handlebars source maps, this should prove relatively straightforward to enable. However, it doesn't seem worth adding even that little bit of complexity now when any such use case isn't yet clear.