### PR TITLE
Generate source maps from Handlebars plugin

### DIFF
--- a/strcalc/src/main/frontend/vite.config.js
+++ b/strcalc/src/main/frontend/vite.config.js
@@ -12,10 +12,17 @@ export function buildDir(relativePath) {
 export default defineConfig({
   base: '/strcalc',
   plugins: [
-    handlebarsPrecompiler({ helpers: ['components/helpers.js'] })
+    handlebarsPrecompiler({
+      helpers: ['components/helpers.js'],
+      sourcemap: true
+    })
   ],
   build: {
-    outDir: buildDir('webapp')
+    outDir: buildDir('webapp'),
+    sourcemap: true
+  },
+  css: {
+    devSourcemap: true
   },
   test: {
     outputFile: buildDir('test-results/test-frontend/TESTS-TestSuites.xml'),


### PR DESCRIPTION
After thinking on it some more, I decided having source maps might be nice. Also, after reading the following, I realized it's actually quite expected:

- https://rollupjs.org/troubleshooting/#warning-sourcemap-is-likely-to-be-incorrect

Some helpful resources on source maps:

- https://web.dev/articles/source-maps
- https://developer.chrome.com/docs/devtools/javascript/source-maps/
- https://www.npmjs.com/package/magic-string