### PR TITLE
Emit Handlebars source map by default

### DIFF
--- a/strcalc/src/main/frontend/package.json
+++ b/strcalc/src/main/frontend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build --emptyOutDir",
+    "build-sourcemap": "vite build --emptyOutDir --sourcemap",
     "preview": "vite preview",
     "lint": "eslint --color --max-warnings 0 .",
     "test": "vitest",

--- a/strcalc/src/main/frontend/rollup-plugin-handlebars-precompiler.js
+++ b/strcalc/src/main/frontend/rollup-plugin-handlebars-precompiler.js
@@ -94,7 +94,14 @@ class PluginImpl {
       delete options.compiler.srcName
       delete options.compiler.destName
     }
-    this.#compilerOpts = options.sourcemap ?
+
+    // This specifies that source maps can be disabled via "sourceMap: false":
+    // - https://rollupjs.org/plugin-development/#source-code-transformations
+    //
+    // This specifies that source maps can be disabled via "sourcemap: false":
+    // - https://rollupjs.org/troubleshooting/#warning-sourcemap-is-likely-to-be-incorrect
+    const sourcemap = options.sourceMap !== false && options.sourcemap !== false
+    this.#compilerOpts = sourcemap ?
       (id) => Object.assign({ srcName: id }, options.compiler) :
       () => options.compiler
   }
@@ -115,7 +122,7 @@ class PluginImpl {
     const opts = this.#compilerOpts(id)
     const ast = Handlebars.parse(code, opts)
     const compiled = Handlebars.precompile(ast, opts)
-    const { code: tmpl = compiled, map: srcMap = null } = compiled
+    const { code: tmpl = compiled, map: srcMap } = compiled
     const collector = new PartialCollector()
     collector.accept(ast)
 
@@ -133,7 +140,7 @@ class PluginImpl {
     ]
     return {
       code: [ ...preTmpl, tmpl, ...postTmpl ].join('\n'),
-      map: srcMap ? this.#adjustSourceMap(srcMap, preTmpl.length) : null
+      map: srcMap ? this.#adjustSourceMap(srcMap, preTmpl.length) : undefined
     }
   }
 

--- a/strcalc/src/main/frontend/vite.config.js
+++ b/strcalc/src/main/frontend/vite.config.js
@@ -12,14 +12,10 @@ export function buildDir(relativePath) {
 export default defineConfig({
   base: '/strcalc',
   plugins: [
-    handlebarsPrecompiler({
-      helpers: ['components/helpers.js'],
-      sourcemap: true
-    })
+    handlebarsPrecompiler({ helpers: ['components/helpers.js'] })
   ],
   build: {
-    outDir: buildDir('webapp'),
-    sourcemap: true
+    outDir: buildDir('webapp')
   },
   css: {
     devSourcemap: true


### PR DESCRIPTION
Reading the following again, emitting the source map should be the default unless explicitly configured via `sourceMap: false` or `sourcemap: false`:

- https://rollupjs.org/plugin-development/#source-code-transformations
- https://rollupjs.org/troubleshooting/#warning-sourcemap-is-likely-to-be-incorrect

So now, if the plugin options contain `sourceMap: false` or `sourcemap: false`, `vite build --sourcemap` will emit the "Sourcemap is likely to be incorrect" warning.

Note the property can be "sourcemap" or "sourceMap", because each of the two above documents use a different version.