### PR TITLE
Run eslint in CI, make max-len ignore URLs

### DIFF
--- a/strcalc/src/main/frontend/.eslintrc
+++ b/strcalc/src/main/frontend/.eslintrc
@@ -27,7 +27,7 @@
       "error"
     ],
     "@stylistic/js/max-len": [
-      "error", 80, 2
+      "error", 80, 2, { "ignoreUrls": true }
     ],
     "@stylistic/js/quotes": [
       "error", "single"

--- a/strcalc/src/main/frontend/package.json
+++ b/strcalc/src/main/frontend/package.json
@@ -12,7 +12,7 @@
     "test": "vitest",
     "test-run": "vitest run",
     "test-ui": "vitest --ui --coverage",
-    "test-ci": "vitest run --config vitest.config.ci-jsdom.js && vitest run --config vitest.config.ci-browser.js",
+    "test-ci": "eslint --color --max-warnings 0 . && vitest run --config vitest.config.ci-jsdom.js && vitest run --config vitest.config.ci-browser.js",
     "coverage": "vitest run --coverage"
   },
   "devDependencies": {

--- a/strcalc/src/main/frontend/rollup-plugin-handlebars-precompiler.js
+++ b/strcalc/src/main/frontend/rollup-plugin-handlebars-precompiler.js
@@ -54,7 +54,6 @@ const HANDLEBARS_PATH = 'handlebars/lib/handlebars.runtime'
 const IMPORT_HANDLEBARS = `import Handlebars from '${HANDLEBARS_PATH}'`
 const IMPORT_HELPERS = `import '${PLUGIN_ID}'`
 
-// eslint-disable-next-line @stylistic/js/max-len
 // https://github.com/handlebars-lang/handlebars.js/blob/master/docs/compiler-api.md
 class PartialCollector extends Handlebars.Visitor {
   partials = []


### PR DESCRIPTION
Fixing the oversight that eslint wasn't running in CI. At the same time, learned that the max-len rule could ignore lines containing URLs:

- https://eslint.style/rules/js/max-len#ignoreurls