### PR TITLE
Start adding JSDoc to strcalc/src/main/frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,19 @@ On macOS and Linux, I installed the latest JDK 21.0.1 from [Eclipse
 Temurin&trade; Latest Releases][] via [SDKMAN!][]. On Windows, I downloaded it
 from the [Download the Microsoft Build of OpenJDK][] page.
 
+### Setup the frontend JavaScript environment
+
+See [strcalc/src/main/frontend/README.md](strcalc/src/main/frontend/README.md)
+for guidance on setting up the frontend development and build environment.
+
+The frontend environment isn't required for `./gradlew test`, which runs the
+small Java unit tests from the exercise. Conversely, the Java environment isn't
+strictly required to develop, build, and test the frontend in isolation.
+
+However, you will need to have both environments installed to build most of the
+Gradle targets. This includes the medium integration and large system tests in
+`strcalc/src/test/java`, which also depend on the frontend build.
+
 ### Optional: Install the [Tomcat servlet container][]
 
 _This step is optional, as the [bin/tomcat-docker.sh][] script will run Tomcat
@@ -739,40 +752,6 @@ plugin:
 - Configure the selected plugin to process the downloaded
 `jacocoXmlTestReport.xml` file.
 
-## Setup frontend JavaScript environment
-
-[Node.js][] is a JavaScript runtime environment. [pnpm][] is a Node.js package
-manager.
-
-- TODO(mbland): Document usage of [nodenv][], [Homebrew][]
-
-[ESLint][] is a tool for formatting and linting JavaScript code.
-
-[Vite][] is a JavaScript development and deployment platform. [Vitest][] is a
-JavaScript test framework and runner designed to work well with Vite.
-
-Though I've had a great experience testing with Mocha, Chai, and Sinon in the
-past, setting them up involves a bit more work.
-
-- [Mocha test framework][]
-- [Chai test assertion library][]
-- [Sinon test double framework][]
-
-In contrast, Vitest is largely modeled after the popular Jest framework and is a
-breeze to set up, especially for existing Vite projects. Like Jest, it contains
-its own assertion library and test double framework.  For the purpose of a
-teaching example for people who may never have tested JavaScript before, but
-aren't using React, Vitest seems much more accessible.
-
-Suffice it to say, ESLint and Vite have IntelliJ IDEA and Visual Studio
-Code support:
-
-- ESLint in IntelliJ IDEA: _Settings > Languages & Frameworks >
-  JavaScript > Code Quality Tools > ESLint_
-- [ESLint extension for Visual Studio Code][]
-- [Vite IntelliJ plugin][]
-- [Vite extension for Visual Studio Code][]
-
 ## Adding large tests
 
 Coming soon...
@@ -785,7 +764,6 @@ TODO(mbland): Document how the following are configured:
 - [TestTomcat](./strcalc/src/test/java/com/mike_bland/training/testing/utils/TestTomcat.java)
   (for medium tests)
 - [node-gradle/gradle-node-plugin][]
-
 
 ## Implementing core logic using Test Driven Development and unit tests
 
@@ -879,17 +857,4 @@ Coming soon...
 [coverallsapp/github-action GitHub Actions plugin]: https://github.com/coverallsapp/github-action
 [GitHub Actions marketplace]: https://github.com/marketplace?type=actions
 [JaCoCo related GitHub Actions plugins]: https://github.com/marketplace?category=&type=actions&verification=&query=jacoco
-[Node.js]: https://nodejs.org/
-[pnpm]: https://pnpm.io/
-[nodenv]: https://github.com/nodenv/nodenv
-[homebrew]: https://brew.sh/
-[ESLint]: https://eslint.style/
-[Vite]: https://vitejs.dev/
-[Vitest]: https://vitest.dev/
-[Mocha test framework]: https://mochajs.org/
-[Chai test assertion library]: https://www.chaijs.com/
-[Sinon test double framework]: https://sinonjs.org/
-[ESLint extension for Visual Studio Code]: https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint
-[Vite IntelliJ plugin]: https://plugins.jetbrains.com/plugin/20011-vite
-[Vite extension for Visual Studio Code]: https://marketplace.visualstudio.com/items?itemName=antfu.vite
 [Selenium: Design patterns and development strategies]: https://www.selenium.dev/documentation/test_practices/design_strategies/

--- a/strcalc/src/main/frontend/.eslintrc
+++ b/strcalc/src/main/frontend/.eslintrc
@@ -1,4 +1,4 @@
-{ "extends": "eslint:recommended",
+{
   "env" : {
     "browser" : true,
     "node": true,
@@ -8,12 +8,22 @@
     "ecmaVersion": "latest",
     "sourceType": "module"
   },
-  "plugins": [ "@stylistic/js", "vitest" ],
+  "plugins": [
+    "@stylistic/js",
+    "vitest",
+    "jsdoc"
+  ],
+  "extends": [
+    "eslint:recommended",
+    "plugin:jsdoc/recommended"
+  ],
   "overrides": [
     {
       "files": ["**/*.test.js"],
       "plugins": ["vitest"],
-      "extends": ["plugin:vitest/recommended"]
+      "extends": [
+        "plugin:vitest/recommended"
+      ]
     }
   ],
   "rules" : {

--- a/strcalc/src/main/frontend/README.md
+++ b/strcalc/src/main/frontend/README.md
@@ -1,0 +1,141 @@
+# Tomcat Servlet Testing Example Frontend
+
+This is the frontend component of the [mbland/tomcat-servlet-testing-example][]
+project. For details on the larger project and the backend component, see the
+[top level README.md][].
+
+The Java environment isn't strictly required to develop, build, and test the
+frontend in isolation. Conversely, the frontend environment isn't required for
+`./gradlew test`, which runs the small Java unit tests from the exercise.
+
+However, you will need to have both environments installed to build most of the
+Gradle targets. This includes the medium integration and large system tests in
+`strcalc/src/test/java`, which also depend on the frontend build.
+
+## Setup frontend JavaScript environment
+
+[Node.js][] is a JavaScript runtime environment. [pnpm][] is a Node.js package
+manager.
+
+- TODO(mbland): Document usage of [nodenv][], [Homebrew][]
+
+[ESLint][] is a tool for formatting and linting JavaScript code.
+
+[Vite][] is a JavaScript development and deployment platform. [Vitest][] is a
+JavaScript test framework and runner designed to work well with Vite.
+
+Though I've had a great experience testing with Mocha, Chai, and Sinon in the
+past, setting them up involves a bit more work.
+
+- [Mocha test framework][]
+- [Chai test assertion library][]
+- [Sinon test double framework][]
+
+In contrast, Vitest is largely modeled after the popular Jest framework and is a
+breeze to set up, especially for existing Vite projects. Like Jest, it contains
+its own assertion library and test double framework.  For the purpose of a
+teaching example for people who may never have tested JavaScript before, but
+aren't using React, Vitest seems much more accessible.
+
+Suffice it to say, ESLint and Vite have IntelliJ IDEA and Visual Studio
+Code support:
+
+- ESLint in IntelliJ IDEA: _Settings > Languages & Frameworks >
+  JavaScript > Code Quality Tools > ESLint_
+- [ESLint extension for Visual Studio Code][]
+- [Vite IntelliJ plugin][]
+- [Vite extension for Visual Studio Code][]
+
+## JSDoc documentation
+
+The inline documentation is written using the [JSDoc][] format. [IntelliJ IDEA][]
+and [Visual Studio Code][] both support JSDoc natively, so there's no need to
+install any extra tools.
+
+However, if you want to generate the HTML version of the documentation, you can run:
+
+```sh
+# If you've never installed a global package with pnpm before
+# - https://pnpm.io/cli/setup
+$ pnpm setup
+[...snip...]
+
+# Install JSDoc globally
+$ pnpm add -g jsdoc
+[...snip...]
+
+# Run the "jsdoc" script from package.json, where "0.0.0" is whatever the
+# current version is now
+$ pnpm jsdoc
+
+> tomcat-servlet-testing-example-frontend@0.0.0 jsdoc .../tomcat-servlet-testing-example/strcalc/src/main/frontend
+> bin/jsdoc -c ./jsdoc.json .
+
+../../../build/jsdoc/tomcat-servlet-testing-example-frontend/0.0.0/index.html
+```
+
+To open the resulting file on macOS, Linux, or a [Bash][]-based environment on
+Windows (e.g., [Git for Windows][], [MSYS2][]):
+
+```sh
+open ../../../build/jsdoc/tomcat-servlet-testing-example-frontend/0.0.0/index.html
+```
+
+On [Windows Subsystem for Linux][]:
+
+```sh
+# If you haven't installed the Windows Subsystem for Linux Utilities
+sudo apt install wslu
+
+# Once WSLU is installed
+wslview ../../../build/jsdoc/tomcat-servlet-testing-example-frontend/0.0.0/index.html
+```
+
+To open it in the [Windows Command Prompt][] or [PowerShell][], just enter the
+path directly at the prompt, or prefix it with [`start`][]:
+
+```bat
+..\..\..\build\jsdoc\tomcat-servlet-testing-example-frontend\0.0.0\index.html
+```
+
+### JSDoc eslint plugin
+
+Note that this project uses [eslint-plugin-jsdoc][] to enforce JSDoc style rules.
+
+### JSDoc quirk
+
+JSDoc can't yet handle objects defined in an `export default` declaration
+without the `@function` tag:
+
+- <https://github.com/jsdoc/jsdoc/issues/1539>
+- <https://github.com/jsdoc/jsdoc/issues/2038>
+
+When that bug gets fixed, I'll remove this comment and the explicit `@function`
+decorators.
+
+[mbland/tomcat-servlet-testing-example]: https://github.com/mbland/tomcat-servlet-testing-example
+[top level README.md]: ../../../../README.md
+[Node.js]: https://nodejs.org/
+[pnpm]: https://pnpm.io/
+[nodenv]: https://github.com/nodenv/nodenv
+[homebrew]: https://brew.sh/
+[ESLint]: https://eslint.style/
+[Vite]: https://vitejs.dev/
+[Vitest]: https://vitest.dev/
+[Mocha test framework]: https://mochajs.org/
+[Chai test assertion library]: https://www.chaijs.com/
+[Sinon test double framework]: https://sinonjs.org/
+[ESLint extension for Visual Studio Code]: https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint
+[Vite IntelliJ plugin]: https://plugins.jetbrains.com/plugin/20011-vite
+[Vite extension for Visual Studio Code]: https://marketplace.visualstudio.com/items?itemName=antfu.vite
+[JSDoc]: https://jsdoc.app/
+[IntelliJ IDEA]: https://www.jetbrains.com/idea/
+[Visual Studio Code]: https://code.visualstudio.com/
+[Bash]: https://www.gnu.org/software/bash/
+[Git for Windows]: https://git-scm.com/download/win
+[MSYS2]: https://www.msys2.org/
+[Windows Subsystem for Linux]: https://learn.microsoft.com/windows/wsl/
+[Windows Command Prompt]: https://learn.microsoft.com/windows-server/administration/windows-commands/windows-commands
+[PowerShell]: https://learn.microsoft.com/powershell/
+[`start`]: https://learn.microsoft.com/windows-server/administration/windows-commands/start
+[eslint-plugin-jsdoc]: https://www.npmjs.com/package/eslint-plugin-jsdoc

--- a/strcalc/src/main/frontend/bin/jsdoc
+++ b/strcalc/src/main/frontend/bin/jsdoc
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# jsdoc wrapper used by the "jsdoc" package.json script
+#
+# Removes the existing destination directory if it exists, runs JSDoc, and emits
+# the relative path to the generated index.html file.
+#
+# Prompts the user to install JSDoc if not present. It's not a package.json
+# devDependency because it seems that many folks browse JSDoc in their IDE
+# without needing to generate the HTML version.
+
+if ! command -v jsdoc > /dev/null; then
+  echo \"Run 'pnpm add -g jsdoc' to install JSDoc: https://jsdoc.app\"
+  exit 1
+fi
+
+ARGS=()
+DESTINATION=""
+
+# Discover the output directory, since JSDoc doesn't have a setting to emit it.
+while [[ "$#" -ne 0 ]]; do
+  curArg="$1"
+  shift
+  ARGS+=("$curArg")
+
+  case "$curArg" in
+  -c|--configure)
+    if [[ -z "$DESTINATION" ]]; then
+      # All bets are off if the destination property contains an escaped '"' or
+      # there's more than one "destination" property defined.
+      DESTINATION="$(sed -ne 's/.*"destination": *"\([^"]*\)".*/\1/p' < "$1")"
+    fi
+    ARGS+=("$1")
+    shift
+    ;;
+  -d|--destination)
+    DESTINATION="$1"
+    ARGS+=("$1")
+    shift
+    ;;
+  *)
+    ;;
+  esac
+done
+
+# "out" is the JSDoc default directory.
+DESTINATION="${DESTINATION:-out}"
+rm -rf "$DESTINATION"
+
+if jsdoc "${ARGS[@]}"; then
+  exec find "$DESTINATION" -name index.html -print -quit
+fi

--- a/strcalc/src/main/frontend/components/helpers.js
+++ b/strcalc/src/main/frontend/components/helpers.js
@@ -7,6 +7,19 @@
  * - https://handlebarsjs.com/guide/expressions.html#helpers
  */
 
+/**
+ * Exports a function to register Handlebars helpers.
+ *
+ * Passed to rollup-plugin-handlebars-precompiler via options.helpers.
+ * @see https://handlebarsjs.com/api-reference/runtime.html#handlebars-registerhelper-name-helper
+ * @module components/helpers
+ */
+
+/**
+ * Registers helper functions via Handlebars.registerHelper().
+ * @function default
+ * @param {module} Handlebars The Handlebars runtime module
+ */
 export default function(Handlebars) {
   Handlebars.registerHelper('link', function(text, options) {
     const attrs = Object.keys(options.hash).map(key => {

--- a/strcalc/src/main/frontend/components/placeholder.js
+++ b/strcalc/src/main/frontend/components/placeholder.js
@@ -2,9 +2,17 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/**
+ * The placeholder component for the String Calculator application
  *
  * This is an example of a JavaScript class representing a web page component,
  * implemented using a precompiled Handlebars template.
+ *
+ * Implemented using Handlebars template compiled via
+ * rollup-plugin-handlebars-precompiler.
+ * @module placeholder
  */
 
 import Template from './placeholder.hbs'

--- a/strcalc/src/main/frontend/init.js
+++ b/strcalc/src/main/frontend/init.js
@@ -5,8 +5,20 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+/**
+ * Initializer for the String Calculator web application.
+ * @module init
+ */
+
 import Placeholder from './components/placeholder'
 
+/**
+ * Instantiates the top level objects and calls the `init()` method on each.
+ *
+ * This is a teaching example that contains minimal business logic in order to
+ * demonstrate how to design much larger applications for testability.
+ * @param {Document} document The DOM window.document object
+ */
 export default function initApp(document) {
   new Placeholder(document).init()
 }

--- a/strcalc/src/main/frontend/jsdoc.json
+++ b/strcalc/src/main/frontend/jsdoc.json
@@ -1,0 +1,14 @@
+{
+  "plugins": [ "plugins/markdown" ],
+  "recurseDepth": 10,
+  "source": {
+    "includePattern": ".+\\.js$",
+    "exclude": ["node_modules"]
+  },
+  "opts": {
+    "destination": "../../../build/jsdoc",
+    "recurse": true,
+    "readme": "README.md",
+    "package": "package.json"
+  }
+}

--- a/strcalc/src/main/frontend/main.js
+++ b/strcalc/src/main/frontend/main.js
@@ -5,6 +5,16 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+/**
+ * Entrypoint of the String Calculator web application.
+ *
+ * Delegates to the 'init' module to initialize the application on
+ * DOMContentLoaded.
+ *
+ * This is a teaching example that contains minimal business logic in order to
+ * demonstrate how to design much larger applications for testability.
+ * @module main
+ */
 import initApp from './init'
 
 document.addEventListener('DOMContentLoaded', () => initApp(document))

--- a/strcalc/src/main/frontend/main.test.js
+++ b/strcalc/src/main/frontend/main.test.js
@@ -1,5 +1,9 @@
 /* eslint-env browser, node, jest, vitest */
-
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 import { describe, afterEach, expect, test } from 'vitest'
 import { PageLoader } from './test-helpers.js'
 

--- a/strcalc/src/main/frontend/package.json
+++ b/strcalc/src/main/frontend/package.json
@@ -1,8 +1,23 @@
 {
-  "name": "strcalc-frontend",
+  "name": "tomcat-servlet-testing-example-frontend",
+  "description": "Frontend component of mbland/tomcat-servlet-testing-example",
   "private": true,
   "version": "0.0.0",
+  "author": "Mike Bland <mbland@acm.org> (https://mike-bland.com/)",
+  "license": "MPL-2.0",
   "type": "module",
+  "browser": "main.js",
+  "engines": {
+    "node": ">=20.10.0",
+    "pnpm": ">=8.11.0"
+  },
+  "homepage": "https://github.com/mbland/tomcat-servlet-testing-example",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mbland/tomcat-servlet-testing-example",
+    "directory": "strcalc/src/main/frontend"
+  },
+  "bugs": "https://github.com/mbland/tomcat-servlet-testing-example/issues",
   "scripts": {
     "dev": "vite",
     "build": "vite build --emptyOutDir",
@@ -13,7 +28,8 @@
     "test-run": "vitest run",
     "test-ui": "vitest --ui --coverage",
     "test-ci": "eslint --color --max-warnings 0 . && vitest run --config vitest.config.ci-jsdom.js && vitest run --config vitest.config.ci-browser.js",
-    "coverage": "vitest run --coverage"
+    "coverage": "vitest run --coverage",
+    "jsdoc": "bin/jsdoc -c ./jsdoc.json ."
   },
   "devDependencies": {
     "@rollup/pluginutils": "^5.1.0",
@@ -23,6 +39,7 @@
     "@vitest/coverage-v8": "1.0.0-beta.4",
     "@vitest/ui": "1.0.0-beta.4",
     "eslint": "^8.54.0",
+    "eslint-plugin-jsdoc": "^46.9.0",
     "eslint-plugin-vitest": "^0.3.10",
     "handlebars": "^4.7.8",
     "jsdom": "^22.1.0",

--- a/strcalc/src/main/frontend/pnpm-lock.yaml
+++ b/strcalc/src/main/frontend/pnpm-lock.yaml
@@ -26,6 +26,9 @@ devDependencies:
   eslint:
     specifier: ^8.54.0
     version: 8.54.0
+  eslint-plugin-jsdoc:
+    specifier: ^46.9.0
+    version: 46.9.0(eslint@8.54.0)
   eslint-plugin-vitest:
     specifier: ^0.3.10
     version: 0.3.10(eslint@8.54.0)(typescript@5.3.2)(vitest@1.0.0-beta.4)
@@ -253,6 +256,15 @@ packages:
 
   /@bcoe/v8-coverage@0.2.3:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+    dev: true
+
+  /@es-joy/jsdoccomment@0.41.0:
+    resolution: {integrity: sha512-aKUhyn1QI5Ksbqcr3fFJj16p99QdjUxXAEuFst1Z47DRyoiMwivIH9MV/ARcJOCXVjPfjITciej8ZD2O/6qUmw==}
+    engines: {node: '>=16'}
+    dependencies:
+      comment-parser: 1.4.1
+      esquery: 1.5.0
+      jsdoc-type-pratt-parser: 4.0.0
     dev: true
 
   /@esbuild/android-arm64@0.18.20:
@@ -1084,6 +1096,11 @@ packages:
       zip-stream: 5.0.1
     dev: true
 
+  /are-docs-informative@0.0.2:
+    resolution: {integrity: sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==}
+    engines: {node: '>=14'}
+    dev: true
+
   /argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
     dev: true
@@ -1201,6 +1218,11 @@ packages:
   /buffers@0.1.1:
     resolution: {integrity: sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==}
     engines: {node: '>=0.2.0'}
+    dev: true
+
+  /builtin-modules@3.3.0:
+    resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
+    engines: {node: '>=6'}
     dev: true
 
   /cac@6.7.14:
@@ -1331,6 +1353,11 @@ packages:
   /commander@9.5.0:
     resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
     engines: {node: ^12.20.0 || >=14}
+    dev: true
+
+  /comment-parser@1.4.1:
+    resolution: {integrity: sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==}
+    engines: {node: '>= 12.0.0'}
     dev: true
 
   /compress-commons@5.0.1:
@@ -1632,6 +1659,26 @@ packages:
       esutils: 2.0.3
     optionalDependencies:
       source-map: 0.6.1
+    dev: true
+
+  /eslint-plugin-jsdoc@46.9.0(eslint@8.54.0):
+    resolution: {integrity: sha512-UQuEtbqLNkPf5Nr/6PPRCtr9xypXY+g8y/Q7gPa0YK7eDhh0y2lWprXRnaYbW7ACgIUvpDKy9X2bZqxtGzBG9Q==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+    dependencies:
+      '@es-joy/jsdoccomment': 0.41.0
+      are-docs-informative: 0.0.2
+      comment-parser: 1.4.1
+      debug: 4.3.4
+      escape-string-regexp: 4.0.0
+      eslint: 8.54.0
+      esquery: 1.5.0
+      is-builtin-module: 3.2.1
+      semver: 7.5.4
+      spdx-expression-parse: 3.0.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /eslint-plugin-vitest@0.3.10(eslint@8.54.0)(typescript@5.3.2)(vitest@1.0.0-beta.4):
@@ -2246,6 +2293,13 @@ packages:
     resolution: {integrity: sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==}
     dev: true
 
+  /is-builtin-module@3.2.1:
+    resolution: {integrity: sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==}
+    engines: {node: '>=6'}
+    dependencies:
+      builtin-modules: 3.3.0
+    dev: true
+
   /is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -2359,6 +2413,11 @@ packages:
     hasBin: true
     dependencies:
       argparse: 2.0.1
+    dev: true
+
+  /jsdoc-type-pratt-parser@4.0.0:
+    resolution: {integrity: sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==}
+    engines: {node: '>=12.0.0'}
     dev: true
 
   /jsdom@22.1.0:
@@ -3204,6 +3263,21 @@ packages:
   /source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /spdx-exceptions@2.3.0:
+    resolution: {integrity: sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==}
+    dev: true
+
+  /spdx-expression-parse@3.0.1:
+    resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
+    dependencies:
+      spdx-exceptions: 2.3.0
+      spdx-license-ids: 3.0.16
+    dev: true
+
+  /spdx-license-ids@3.0.16:
+    resolution: {integrity: sha512-eWN+LnM3GR6gPu35WxNgbGl8rmY1AEmoMDvL/QD6zYmPWgywxWqJWNdLGT+ke8dKNWrcYgYjPpG5gbTfghP8rw==}
     dev: true
 
   /split2@4.2.0:

--- a/strcalc/src/main/frontend/rollup-plugin-handlebars-precompiler.js
+++ b/strcalc/src/main/frontend/rollup-plugin-handlebars-precompiler.js
@@ -33,6 +33,11 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file, You can
 // obtain one at https://mozilla.org/MPL/2.0/.
 
+/**
+ * A Rollup plugin object for precompiling Handlebars templates.
+ * @module rollup-plugin-handlebars-precompiler
+ */
+
 import { createFilter } from '@rollup/pluginutils'
 import Handlebars from 'handlebars'
 
@@ -71,6 +76,9 @@ class PartialCollector extends Handlebars.Visitor {
   collect(n) { if (n.type === 'PathExpression') this.partials.push(n.original) }
 }
 
+/**
+ * Rollup Handlebars precompiler implementation
+ */
 class PluginImpl {
   #helpers
   #importHelpers
@@ -158,6 +166,12 @@ class PluginImpl {
   }
 }
 
+/**
+ * Returns a Rollup plugin object for precompiling Handlebars templates.
+ * @function default
+ * @param {object} options object containing Handlebars compiler API options
+ * @returns {object} a Rollup plugin that precompiles Handlebars templates
+ */
 export default function(options) {
   const p = new PluginImpl(options)
   return {

--- a/strcalc/src/main/frontend/test-helpers.js
+++ b/strcalc/src/main/frontend/test-helpers.js
@@ -1,5 +1,18 @@
 /* eslint-env browser, node */
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 
+/**
+ * Exports test helper utilities for this project.
+ * @module test-helpers
+ */
+
+/**
+ * Enables tests to load page URLs both in the browser and in Node using JSDom.
+ */
 export class PageLoader {
   static #impl
 
@@ -255,7 +268,7 @@ class JsdomPageLoader {
         // load event.
         global.window = window
         global.document = document
-        await this.#importModules(window, document)
+        await this.#importModules(document)
 
         // The DOMContentLoaded and load events registered by JSDOM.fromFile()
         // will already have fired by this point.
@@ -286,11 +299,16 @@ class JsdomPageLoader {
   }
 }
 
-// Imports <script type="module"> elements parsed, but not executed, by JSDOM.
-//
-// Only works with scripts with a `src` attribute; it will not execute inline
-// code.
-function importModulesDynamically(win, doc) {
+/**
+ * Imports <script type="module"> elements parsed, but not executed, by JSDOM.
+ *
+ * Only works with scripts with a `src` attribute; it will not execute inline
+ * code.
+ * @private
+ * @param {Document} doc  the JSDOM window.document object
+ * @returns {Promise}  a Promise resolved after importing all JS modules in doc
+ */
+function importModulesDynamically(doc) {
   let modules = doc.querySelectorAll('script[type="module"]')
   return Promise.all(Array.from(modules).map(m => import(m.src)))
 }

--- a/strcalc/src/main/frontend/vite.config.js
+++ b/strcalc/src/main/frontend/vite.config.js
@@ -5,6 +5,12 @@ import path from 'node:path/posix'
 
 const BUILD_DIR = path.resolve('../../../build/')
 
+/**
+ * Resolves a file system path relative to the project's BUILD_DIR.
+ * @private
+ * @param {string} relativePath path within the BUILD_DIR to construct
+ * @returns {string} the relativePath resolved to BUILD_DIR
+ */
 export function buildDir(relativePath) {
   return path.resolve(BUILD_DIR, relativePath)
 }


### PR DESCRIPTION
https://jsdoc.app/

The JSDoc-ification isn't complete here, but these following changes make for a good start:

- Added the bin/jsdoc wrapper to clean any existing output, prompt the user to install jsdoc if needed, and print the path to new index.html
- Defined the jsdoc.json configuration object
  - Sets the destination directory to ../../../build/jsdoc
  - Sets the "readme" and "package" options, which didn't appear to use the builtin defaults
- Added the "jsdoc" script to package.json
- Added eslint-plugin-jsdoc as a devDependency and configured it accordingly
- Added a new strcalc/src/main/frontend/README.md to include in the JSDoc, moving frontend info from the top level README.md
  - https://jsdoc.app/about-including-readme
- Updated package.json with more info, some used by JSDoc
  - https://docs.npmjs.com/cli/v10/configuring-npm/package-json
  - https://jsdoc.app/about-including-package
- Added initial JSDoc comments everywhere required by 'pnpm lint', plus a few extra
- Added the MPL-2.0 file notice to a couple files that needed it

The one logical change here was:

- Removed the now unnecessary "win" (for "window") argument from importModulesDynamically(doc) in test-helpers.js

Normally I'd split a change this large across commits and pull requests. Since it's mostly documentation and configuration in this case, which I picked at back and forth, I'm OK submitting this larger blob. (Especially since I did document all the little changes above.)

I started learning about JSDoc when I was researching how to resolve IntelliJ warnings for things that clearly aren't problems. Apparently adding JSDoc will accompish this in many cases.

Apparently, many folks don't even install the 'jsdoc' tool because IDEs usually already integrate it. This is why it's not a devDependency, but the bin/jsdoc will prompt the user to install it if they ever run "pnpm jsdoc".