### PR TITLE
Bump eslint-plugin-js, webdriverio, update README

### DIFF
--- a/strcalc/src/main/frontend/README.md
+++ b/strcalc/src/main/frontend/README.md
@@ -113,6 +113,73 @@ without the `@function` tag:
 When that bug gets fixed, I'll remove this comment and the explicit `@function`
 decorators.
 
+## Optional: Use local repo for Vitest packages
+
+The current version of Vitest breaks on this project because `config.base` is
+specified in `vite.config.js`. See:
+
+- https://github.com/vitest-dev/vitest/issues/4686
+
+Once the following pull request is merged and released, we can release the
+revlock and upgrade both Vite and Vitest:
+
+- https://github.com/vitest-dev/vitest/pull/4692
+
+In the meanwhile, I'm publishing this fix in my **mbland/vitest** fork using
+tags of the format `v1.0.2-mbland.0`:
+
+- https://github.com/mbland/vitest/tree/v1.0.2-mbland.0
+
+To use this package, first clone it and build it in the same parent directory
+containing this repository, replacing `v1.0.2-mbland.0` with the latest tag:
+
+```sh
+git clone git@github.com:mbland/vitest.git
+cd vitest
+git reset --hard v1.0.2-mbland.0
+pnpm i
+pnpm build
+cd packages/browser
+pnpm pack
+```
+
+Then apply changes like the following to `package.json`, followed by `pnpm i`:
+
+```diff
+diff --git a/strcalc/src/main/frontend/package.json b/strcalc/src/main/frontend/package.json
+index be373d8..7039359 100644
+--- a/strcalc/src/main/frontend/package.json
++++ b/strcalc/src/main/frontend/package.json
+@@ -34,17 +34,17 @@
+   "devDependencies": {
+     "@rollup/pluginutils": "^5.1.0",
+     "@stylistic/eslint-plugin-js": "^1.5.0",
+-    "@vitest/browser": "1.0.0-beta.4",
+-    "@vitest/coverage-istanbul": "1.0.0-beta.4",
+-    "@vitest/coverage-v8": "1.0.0-beta.4",
+-    "@vitest/ui": "1.0.0-beta.4",
++    "@vitest/browser": "file:../../../../../vitest/packages/browser/vitest-browser-1.0.2.tgz",
++    "@vitest/coverage-istanbul": "1.0.2",
++    "@vitest/coverage-v8": "1.0.2",
++    "@vitest/ui": "1.0.2",
+     "eslint": "^8.55.0",
+     "eslint-plugin-jsdoc": "^46.9.0",
+     "eslint-plugin-vitest": "^0.3.10",
+     "handlebars": "^4.7.8",
+     "jsdom": "^23.0.1",
+-    "vite": "^4.5.1",
+-    "vitest": "1.0.0-beta.4",
++    "vite": "^5.0.7",
++    "vitest": "1.0.2",
+     "webdriverio": "^8.26.0"
+   }
+ }
+```
+
+You'll need to be careful not to commit these changes. You can `git stash` them
+or run `git reset --hard head`, followed by `pnpm i` to match the CI build
+again.
+
 [mbland/tomcat-servlet-testing-example]: https://github.com/mbland/tomcat-servlet-testing-example
 [top level README.md]: ../../../../README.md
 [Node.js]: https://nodejs.org/

--- a/strcalc/src/main/frontend/package.json
+++ b/strcalc/src/main/frontend/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@rollup/pluginutils": "^5.1.0",
-    "@stylistic/eslint-plugin-js": "^1.4.1",
+    "@stylistic/eslint-plugin-js": "^1.5.0",
     "@vitest/browser": "1.0.0-beta.4",
     "@vitest/coverage-istanbul": "1.0.0-beta.4",
     "@vitest/coverage-v8": "1.0.0-beta.4",
@@ -45,6 +45,6 @@
     "jsdom": "^23.0.1",
     "vite": "^4.5.1",
     "vitest": "1.0.0-beta.4",
-    "webdriverio": "^8.24.6"
+    "webdriverio": "^8.26.0"
   }
 }

--- a/strcalc/src/main/frontend/pnpm-lock.yaml
+++ b/strcalc/src/main/frontend/pnpm-lock.yaml
@@ -9,11 +9,11 @@ devDependencies:
     specifier: ^5.1.0
     version: 5.1.0
   '@stylistic/eslint-plugin-js':
-    specifier: ^1.4.1
-    version: 1.4.1(eslint@8.55.0)
+    specifier: ^1.5.0
+    version: 1.5.0(eslint@8.55.0)
   '@vitest/browser':
     specifier: 1.0.0-beta.4
-    version: 1.0.0-beta.4(vitest@1.0.0-beta.4)(webdriverio@8.24.6)
+    version: 1.0.0-beta.4(vitest@1.0.0-beta.4)(webdriverio@8.26.0)
   '@vitest/coverage-istanbul':
     specifier: 1.0.0-beta.4
     version: 1.0.0-beta.4(vitest@1.0.0-beta.4)
@@ -31,7 +31,7 @@ devDependencies:
     version: 46.9.0(eslint@8.55.0)
   eslint-plugin-vitest:
     specifier: ^0.3.10
-    version: 0.3.10(eslint@8.55.0)(typescript@5.3.2)(vitest@1.0.0-beta.4)
+    version: 0.3.10(eslint@8.55.0)(typescript@5.3.3)(vitest@1.0.0-beta.4)
   handlebars:
     specifier: ^4.7.8
     version: 4.7.8
@@ -45,8 +45,8 @@ devDependencies:
     specifier: 1.0.0-beta.4
     version: 1.0.0-beta.4(@vitest/browser@1.0.0-beta.4)(@vitest/ui@1.0.0-beta.4)(jsdom@23.0.1)
   webdriverio:
-    specifier: ^8.24.6
-    version: 8.24.6(typescript@5.3.2)
+    specifier: ^8.26.0
+    version: 8.26.0(typescript@5.3.3)
 
 packages:
 
@@ -604,11 +604,11 @@ packages:
     dev: true
     optional: true
 
-  /@polka/url@1.0.0-next.23:
-    resolution: {integrity: sha512-C16M+IYz0rgRhWZdCmK+h58JMv8vijAA61gmz2rspCSwKwzBebpdcsiUmwrtJRdphuY30i6BSLEOP8ppbNLyLg==}
+  /@polka/url@1.0.0-next.24:
+    resolution: {integrity: sha512-2LuNTFBIO0m7kKIQvvPHN6UE63VjpmL9rnEEaOOaiSPbZK+zUOYIzBAWcED+3XYzhYsd/0mD57VdxAEqqV52CQ==}
     dev: true
 
-  /@puppeteer/browsers@1.4.6(typescript@5.3.2):
+  /@puppeteer/browsers@1.4.6(typescript@5.3.3):
     resolution: {integrity: sha512-x4BEjr2SjOPowNeiguzjozQbsc6h437ovD/wu+JpaenxVLm3jkgzHY2xOslMTp50HoTvQreMjiexiGQw1sqZlQ==}
     engines: {node: '>=16.3.0'}
     hasBin: true
@@ -623,15 +623,15 @@ packages:
       progress: 2.0.3
       proxy-agent: 6.3.0
       tar-fs: 3.0.4
-      typescript: 5.3.2
+      typescript: 5.3.3
       unbzip2-stream: 1.4.3
       yargs: 17.7.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@puppeteer/browsers@1.8.0:
-    resolution: {integrity: sha512-TkRHIV6k2D8OlUe8RtG+5jgOF/H98Myx0M6AOafC8DdNVOFiBSFa5cpRDtpm8LXOa9sVwe0+e6Q3FC56X/DZfg==}
+  /@puppeteer/browsers@1.9.0:
+    resolution: {integrity: sha512-QwguOLy44YBGC8vuPP2nmpX4MUN2FzWbsnvZJtiCzecU3lHmVZkaC1tq6rToi9a200m8RzlVtDyxCS0UIDrxUg==}
     engines: {node: '>=16.3.0'}
     hasBin: true
     dependencies:
@@ -669,8 +669,8 @@ packages:
     engines: {node: '>=14.16'}
     dev: true
 
-  /@stylistic/eslint-plugin-js@1.4.1(eslint@8.55.0):
-    resolution: {integrity: sha512-WXHPEVw5PB7OML7cLwHJDEcCyLiP7vzKeBbSwmpHLK0oh0JYkoJfTg2hEdFuQT5rQxFy3KzCy9R1mZ0wgLjKrA==}
+  /@stylistic/eslint-plugin-js@1.5.0(eslint@8.55.0):
+    resolution: {integrity: sha512-TuGQv1bsIshkbJUInCewp4IUWy24W5RFiVNMV0quPSkuZ8gsYoqq6kLHvvaxpjxN9TvwSoOIwnhgrYKei2Tgcw==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       eslint: '>=8.40.0'
@@ -710,8 +710,8 @@ packages:
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
     dev: true
 
-  /@types/node@20.10.3:
-    resolution: {integrity: sha512-XJavIpZqiXID5Yxnxv3RUDKTN5b81ddNC3ecsA0SoFXz/QU8OGBwZGMomiq0zw+uuqbL/krztv/DINAQ/EV4gg==}
+  /@types/node@20.10.4:
+    resolution: {integrity: sha512-D08YG6rr8X90YB56tSIuBaddy/UXAA9RKJoFvrsnogAum/0pmjkgi4+2nx96A330FmioegBWmEYQ+syqCFaveg==}
     dependencies:
       undici-types: 5.26.5
     dev: true
@@ -727,32 +727,32 @@ packages:
   /@types/ws@8.5.10:
     resolution: {integrity: sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==}
     dependencies:
-      '@types/node': 20.10.3
+      '@types/node': 20.10.4
     dev: true
 
   /@types/yauzl@2.10.3:
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
     requiresBuild: true
     dependencies:
-      '@types/node': 20.10.3
+      '@types/node': 20.10.4
     dev: true
     optional: true
 
-  /@typescript-eslint/scope-manager@6.13.1:
-    resolution: {integrity: sha512-BW0kJ7ceiKi56GbT2KKzZzN+nDxzQK2DS6x0PiSMPjciPgd/JRQGMibyaN2cPt2cAvuoH0oNvn2fwonHI+4QUQ==}
+  /@typescript-eslint/scope-manager@6.13.2:
+    resolution: {integrity: sha512-CXQA0xo7z6x13FeDYCgBkjWzNqzBn8RXaE3QVQVIUm74fWJLkJkaHmHdKStrxQllGh6Q4eUGyNpMe0b1hMkXFA==}
     engines: {node: ^16.0.0 || >=18.0.0}
     dependencies:
-      '@typescript-eslint/types': 6.13.1
-      '@typescript-eslint/visitor-keys': 6.13.1
+      '@typescript-eslint/types': 6.13.2
+      '@typescript-eslint/visitor-keys': 6.13.2
     dev: true
 
-  /@typescript-eslint/types@6.13.1:
-    resolution: {integrity: sha512-gjeEskSmiEKKFIbnhDXUyiqVma1gRCQNbVZ1C8q7Zjcxh3WZMbzWVfGE9rHfWd1msQtPS0BVD9Jz9jded44eKg==}
+  /@typescript-eslint/types@6.13.2:
+    resolution: {integrity: sha512-7sxbQ+EMRubQc3wTfTsycgYpSujyVbI1xw+3UMRUcrhSy+pN09y/lWzeKDbvhoqcRbHdc+APLs/PWYi/cisLPg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree@6.13.1(typescript@5.3.2):
-    resolution: {integrity: sha512-sBLQsvOC0Q7LGcUHO5qpG1HxRgePbT6wwqOiGLpR8uOJvPJbfs0mW3jPA3ujsDvfiVwVlWUDESNXv44KtINkUQ==}
+  /@typescript-eslint/typescript-estree@6.13.2(typescript@5.3.3):
+    resolution: {integrity: sha512-SuD8YLQv6WHnOEtKv8D6HZUzOub855cfPnPMKvdM/Bh1plv1f7Q/0iFUDLKKlxHcEstQnaUU4QZskgQq74t+3w==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       typescript: '*'
@@ -760,20 +760,20 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/types': 6.13.1
-      '@typescript-eslint/visitor-keys': 6.13.1
+      '@typescript-eslint/types': 6.13.2
+      '@typescript-eslint/visitor-keys': 6.13.2
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
-      ts-api-utils: 1.0.3(typescript@5.3.2)
-      typescript: 5.3.2
+      ts-api-utils: 1.0.3(typescript@5.3.3)
+      typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@6.13.1(eslint@8.55.0)(typescript@5.3.2):
-    resolution: {integrity: sha512-ouPn/zVoan92JgAegesTXDB/oUp6BP1v8WpfYcqh649ejNc9Qv+B4FF2Ff626kO1xg0wWwwG48lAJ4JuesgdOw==}
+  /@typescript-eslint/utils@6.13.2(eslint@8.55.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-b9Ptq4eAZUym4idijCRzl61oPCwwREcfDI8xGk751Vhzig5fFZR9CyzDz4Sp/nxSLBYxUPyh4QdIDqWykFhNmQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
@@ -781,9 +781,9 @@ packages:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.55.0)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.5.6
-      '@typescript-eslint/scope-manager': 6.13.1
-      '@typescript-eslint/types': 6.13.1
-      '@typescript-eslint/typescript-estree': 6.13.1(typescript@5.3.2)
+      '@typescript-eslint/scope-manager': 6.13.2
+      '@typescript-eslint/types': 6.13.2
+      '@typescript-eslint/typescript-estree': 6.13.2(typescript@5.3.3)
       eslint: 8.55.0
       semver: 7.5.4
     transitivePeerDependencies:
@@ -791,11 +791,11 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/visitor-keys@6.13.1:
-    resolution: {integrity: sha512-NDhQUy2tg6XGNBGDRm1XybOHSia8mcXmlbKWoQP+nm1BIIMxa55shyJfZkHpEBN62KNPLrocSM2PdPcaLgDKMQ==}
+  /@typescript-eslint/visitor-keys@6.13.2:
+    resolution: {integrity: sha512-OGznFs0eAQXJsp+xSd6k/O1UbFi/K/L7WjqeRoFE7vadjAF9y0uppXhYNQNEqygjou782maGClOoZwPqF0Drlw==}
     engines: {node: ^16.0.0 || >=18.0.0}
     dependencies:
-      '@typescript-eslint/types': 6.13.1
+      '@typescript-eslint/types': 6.13.2
       eslint-visitor-keys: 3.4.3
     dev: true
 
@@ -803,7 +803,7 @@ packages:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
     dev: true
 
-  /@vitest/browser@1.0.0-beta.4(vitest@1.0.0-beta.4)(webdriverio@8.24.6):
+  /@vitest/browser@1.0.0-beta.4(vitest@1.0.0-beta.4)(webdriverio@8.26.0):
     resolution: {integrity: sha512-+FBLmcuPMIn2zO/7EljxwhK3oMlHa6bfkDtBvtU/tyEd3udabfoaiCGoRcsxKV9+GLykbf+pyUAMvqvalfqakg==}
     peerDependencies:
       playwright: '*'
@@ -822,7 +822,7 @@ packages:
       magic-string: 0.30.5
       sirv: 2.0.3
       vitest: 1.0.0-beta.4(@vitest/browser@1.0.0-beta.4)(@vitest/ui@1.0.0-beta.4)(jsdom@23.0.1)
-      webdriverio: 8.24.6(typescript@5.3.2)
+      webdriverio: 8.26.0(typescript@5.3.3)
     dev: true
 
   /@vitest/coverage-istanbul@1.0.0-beta.4(vitest@1.0.0-beta.4):
@@ -916,23 +916,23 @@ packages:
       pretty-format: 29.7.0
     dev: true
 
-  /@wdio/config@8.24.6:
-    resolution: {integrity: sha512-ZFmd6rB1kgL4k/SjLXbtFTCxvxSf1qzdt/losiTqkqFBYznkTRUBGSoGaVTlkMtHAReiVSK92sICc15JWaCdEA==}
+  /@wdio/config@8.24.12:
+    resolution: {integrity: sha512-3HW7qG1rIHzOIybV6oHR1CqLghsN0G3Xzs90ZciGL8dYhtcLtYCHwuWmBw4mkaB5xViU4AmZDuj7ChiG8Cr6Qw==}
     engines: {node: ^16.13 || >=18}
     dependencies:
-      '@wdio/logger': 8.16.17
-      '@wdio/types': 8.24.2
-      '@wdio/utils': 8.24.6
+      '@wdio/logger': 8.24.12
+      '@wdio/types': 8.24.12
+      '@wdio/utils': 8.24.12
       decamelize: 6.0.0
       deepmerge-ts: 5.1.0
       glob: 10.3.10
-      import-meta-resolve: 3.1.1
+      import-meta-resolve: 4.0.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@wdio/logger@8.16.17:
-    resolution: {integrity: sha512-zeQ41z3T+b4IsrriZZipayXxLNDuGsm7TdExaviNGojPVrIsQUCSd/FvlLHM32b7ZrMyInHenu/zx1cjAZO71g==}
+  /@wdio/logger@8.24.12:
+    resolution: {integrity: sha512-QisOiVIWKTUCf1H7S+DOtC+gruhlpimQrUXfWMTeeh672PvAJYnTpOJDWA+BtXfsikkUYFAzAaq8SeMJk8rqKg==}
     engines: {node: ^16.13 || >=18}
     dependencies:
       chalk: 5.3.0
@@ -941,38 +941,37 @@ packages:
       strip-ansi: 7.1.0
     dev: true
 
-  /@wdio/protocols@8.23.0:
-    resolution: {integrity: sha512-2XTzD+lqQP3g8BWn+Bn5BTFzjHqzZNwq7DjlYrb27Bq8nOA+1DEcj3WzQ6V6CktTnKI/LAYKA1IFAF//Azrp/Q==}
+  /@wdio/protocols@8.24.12:
+    resolution: {integrity: sha512-QnVj3FkapmVD3h2zoZk+ZQ8gevSj9D9MiIQIy8eOnY4FAneYZ9R9GvoW+mgNcCZO8S8++S/jZHetR8n+8Q808g==}
     dev: true
 
-  /@wdio/repl@8.23.1:
-    resolution: {integrity: sha512-u6zG2cgBm67V5/WlQzadWqLGXs3moH8MOsgoljULQncelSBBZGZ5DyLB4p7jKcUAsKtMjgmFQmIvpQoqmyvdfg==}
+  /@wdio/repl@8.24.12:
+    resolution: {integrity: sha512-321F3sWafnlw93uRTSjEBVuvWCxTkWNDs7ektQS15drrroL3TMeFOynu4rDrIz0jXD9Vas0HCD2Tq/P0uxFLdw==}
     engines: {node: ^16.13 || >=18}
     dependencies:
-      '@types/node': 20.10.3
+      '@types/node': 20.10.4
     dev: true
 
-  /@wdio/types@8.24.2:
-    resolution: {integrity: sha512-x7iWF5NM8NfVxziGwLdQ+3sstgSxRoqfmmFEDTDps0oFrN5CgkqcoLkqXJ5u166gvpxpEq0gxZwxkbPC/Lp0cw==}
+  /@wdio/types@8.24.12:
+    resolution: {integrity: sha512-SaD3OacDiW06DvSgAQ7sDBbpiI9qZRg7eoVYeBg3uSGVtUq84vTETRhhV7D6xTC00IqZu+mmN2TY5/q+7Gqy7w==}
     engines: {node: ^16.13 || >=18}
     dependencies:
-      '@types/node': 20.10.3
+      '@types/node': 20.10.4
     dev: true
 
-  /@wdio/utils@8.24.6:
-    resolution: {integrity: sha512-qwcshLH9iKnhK0jXoXjPw3G02UhyShT0I+ljC0hMybJEBsra92TYFa47Cp6n1fdvM3+/BTuhsgtzRz0anObicQ==}
+  /@wdio/utils@8.24.12:
+    resolution: {integrity: sha512-uzwZyBVgqz0Wz1KL3aOUaQsxT8TNkzxti4NNTSMrU256qAPqc/n75rB7V73QASapCMpy70mZZTsuPgQYYj4ytQ==}
     engines: {node: ^16.13 || >=18}
     dependencies:
-      '@puppeteer/browsers': 1.8.0
-      '@wdio/logger': 8.16.17
-      '@wdio/types': 8.24.2
+      '@puppeteer/browsers': 1.9.0
+      '@wdio/logger': 8.24.12
+      '@wdio/types': 8.24.12
       decamelize: 6.0.0
       deepmerge-ts: 5.1.0
       edgedriver: 5.3.8
       geckodriver: 4.2.1
       get-port: 7.0.0
-      got: 13.0.0
-      import-meta-resolve: 3.1.1
+      import-meta-resolve: 4.0.0
       locate-app: 2.1.0
       safaridriver: 0.1.0
       split2: 4.2.0
@@ -989,8 +988,8 @@ packages:
       acorn: 8.11.2
     dev: true
 
-  /acorn-walk@8.3.0:
-    resolution: {integrity: sha512-FS7hV565M5l1R08MXqo8odwMTB02C2UqzB17RVgu9EyuYFBqJZ3/ZY97sQD5FewVu1UyDFc1yztUDrAwT0EypA==}
+  /acorn-walk@8.3.1:
+    resolution: {integrity: sha512-TgUZgYvqZprrl7YldZNoa9OciCAyZR+Ejm9eXzKCmjsF5IKp/wgQ7Z/ZpjpGTIUPwrHQIcYeI8qDh4PsEwxMbw==}
     engines: {node: '>=0.4.0'}
     dev: true
 
@@ -1175,7 +1174,7 @@ packages:
     hasBin: true
     dependencies:
       caniuse-lite: 1.0.30001566
-      electron-to-chromium: 1.4.601
+      electron-to-chromium: 1.4.609
       node-releases: 2.0.14
       update-browserslist-db: 1.0.13(browserslist@4.22.2)
     dev: true
@@ -1499,8 +1498,8 @@ packages:
     resolution: {integrity: sha512-hyWmRrexdhbZ1tcJUGpO95ivbRhWXz++F4Ko+n21AY5PNln2ovoJw+8ZMNDTtip+CNFQfrtLVh/w4009dXO/eQ==}
     dev: true
 
-  /devtools-protocol@0.0.1213968:
-    resolution: {integrity: sha512-o4n/beY+3CcZwFctYapjGelKptR4AuQT5gXS1Kvgbig+ArwkxK7f8wDVuD1wsoswiJWCwV6OK+Qb7vhNzNmABQ==}
+  /devtools-protocol@0.0.1233178:
+    resolution: {integrity: sha512-jmMfyaqlzddwmDaSR1AQ+5ek+f7rupZdxKuPdkRcoxrZoF70Idg/4dTgXA08TLPmwAwB54gh49Wm2l/gRM0eUg==}
     dev: true
 
   /diff-sequences@29.6.3:
@@ -1545,7 +1544,7 @@ packages:
     hasBin: true
     requiresBuild: true
     dependencies:
-      '@wdio/logger': 8.16.17
+      '@wdio/logger': 8.24.12
       decamelize: 6.0.0
       edge-paths: 3.0.5
       node-fetch: 3.3.2
@@ -1553,8 +1552,8 @@ packages:
       which: 4.0.0
     dev: true
 
-  /electron-to-chromium@1.4.601:
-    resolution: {integrity: sha512-SpwUMDWe9tQu8JX5QCO1+p/hChAi9AE9UpoC3rcHVc+gdCGlbT3SGb5I1klgb952HRIyvt9wZhSz9bNBYz9swA==}
+  /electron-to-chromium@1.4.609:
+    resolution: {integrity: sha512-ihiCP7PJmjoGNuLpl7TjNA8pCQWu09vGyjlPYw1Rqww4gvNuCcmvl+44G+2QyJ6S2K4o+wbTS++Xz0YN8Q9ERw==}
     dev: true
 
   /emoji-regex@8.0.0:
@@ -1653,7 +1652,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-vitest@0.3.10(eslint@8.55.0)(typescript@5.3.2)(vitest@1.0.0-beta.4):
+  /eslint-plugin-vitest@0.3.10(eslint@8.55.0)(typescript@5.3.3)(vitest@1.0.0-beta.4):
     resolution: {integrity: sha512-08lj4rdhZHYyHk+Py2nJ7SlE6arP8GNfGXl9jVqhe9s5JoZIGiBpIkLGX+VNBiB6vXTn56H6Ant7Koc6XzRjtQ==}
     engines: {node: 14.x || >= 16}
     peerDependencies:
@@ -1666,7 +1665,7 @@ packages:
       vitest:
         optional: true
     dependencies:
-      '@typescript-eslint/utils': 6.13.1(eslint@8.55.0)(typescript@5.3.2)
+      '@typescript-eslint/utils': 6.13.2(eslint@8.55.0)(typescript@5.3.3)
       eslint: 8.55.0
       vitest: 1.0.0-beta.4(@vitest/browser@1.0.0-beta.4)(@vitest/ui@1.0.0-beta.4)(jsdom@23.0.1)
     transitivePeerDependencies:
@@ -1953,7 +1952,7 @@ packages:
     hasBin: true
     requiresBuild: true
     dependencies:
-      '@wdio/logger': 8.16.17
+      '@wdio/logger': 8.24.12
       decamelize: 6.0.0
       http-proxy-agent: 7.0.0
       https-proxy-agent: 7.0.2
@@ -2097,23 +2096,6 @@ packages:
       responselike: 3.0.0
     dev: true
 
-  /got@13.0.0:
-    resolution: {integrity: sha512-XfBk1CxOOScDcMr9O1yKkNaQyy865NbYs+F7dr4H0LZMVgCj2Le59k6PqbNHoL5ToeaEQUYh6c6yMfVcc6SJxA==}
-    engines: {node: '>=16'}
-    dependencies:
-      '@sindresorhus/is': 5.6.0
-      '@szmarczak/http-timer': 5.0.1
-      cacheable-lookup: 7.0.0
-      cacheable-request: 10.2.14
-      decompress-response: 6.0.0
-      form-data-encoder: 2.1.4
-      get-stream: 6.0.1
-      http2-wrapper: 2.2.1
-      lowercase-keys: 3.0.0
-      p-cancelable: 3.0.0
-      responselike: 3.0.0
-    dev: true
-
   /graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
     dev: true
@@ -2216,8 +2198,8 @@ packages:
       resolve-from: 4.0.0
     dev: true
 
-  /import-meta-resolve@3.1.1:
-    resolution: {integrity: sha512-qeywsE/KC3w9Fd2ORrRDUw6nS/nLwZpXgfrOc2IILvZYnCaEMd+D56Vfg9k4G29gIeVi3XKql1RQatME8iYsiw==}
+  /import-meta-resolve@4.0.0:
+    resolution: {integrity: sha512-okYUR7ZQPH+efeuMJGlq4f8ubUgO50kByRPyt/Cy1Io4PSRsPjxME+YlVaCOx+NIToW7hCsZNFJyTPFFKepRSA==}
     dev: true
 
   /imurmurhash@0.1.4:
@@ -2951,7 +2933,7 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /puppeteer-core@20.9.0(typescript@5.3.2):
+  /puppeteer-core@20.9.0(typescript@5.3.3):
     resolution: {integrity: sha512-H9fYZQzMTRrkboEfPmf7m3CLDN6JvbxXA3qTtS+dFt27tR+CsFHzPsT6pzp6lYL6bJbAPaR0HaPO6uSi+F94Pg==}
     engines: {node: '>=16.3.0'}
     peerDependencies:
@@ -2960,12 +2942,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@puppeteer/browsers': 1.4.6(typescript@5.3.2)
+      '@puppeteer/browsers': 1.4.6(typescript@5.3.3)
       chromium-bidi: 0.4.16(devtools-protocol@0.0.1147663)
       cross-fetch: 4.0.0
       debug: 4.3.4
       devtools-protocol: 0.0.1147663
-      typescript: 5.3.2
+      typescript: 5.3.3
       ws: 8.13.0
     transitivePeerDependencies:
       - bufferutil
@@ -3170,7 +3152,7 @@ packages:
     resolution: {integrity: sha512-O9jm9BsID1P+0HOi81VpXPoDxYP374pkOLzACAoyUQ/3OUVndNpsz6wMnY2z+yOxzbllCKZrM+9QrWsv4THnyA==}
     engines: {node: '>= 10'}
     dependencies:
-      '@polka/url': 1.0.0-next.23
+      '@polka/url': 1.0.0-next.24
       mrmime: 1.0.1
       totalist: 3.0.1
     dev: true
@@ -3242,8 +3224,8 @@ packages:
     resolution: {integrity: sha512-aFZ19IgVmhdB2uX599ve2kE6BIE3YMnQ6Gp6BURhW/oIzpXGKr878TQfAQZn1+i0Flcc/UKUy1gOlcfaUBCryg==}
     dev: true
 
-  /streamx@2.15.5:
-    resolution: {integrity: sha512-9thPGMkKC2GctCzyCUjME3yR03x2xNo0GPKGkRw2UMYN+gqWa9uqpyNWhmsNCutU5zHmkUum0LsCRQTXUgUCAg==}
+  /streamx@2.15.6:
+    resolution: {integrity: sha512-q+vQL4AAz+FdfT137VF69Cc/APqUbxy+MDOImRrMvchJpigHj9GksgDU2LYbO9rx7RX6osWgxJB2WxhYv4SZAw==}
     dependencies:
       fast-fifo: 1.3.2
       queue-tick: 1.0.1
@@ -3335,7 +3317,7 @@ packages:
     dependencies:
       b4a: 1.6.4
       fast-fifo: 1.3.2
-      streamx: 2.15.5
+      streamx: 2.15.6
     dev: true
 
   /test-exclude@6.0.0:
@@ -3411,13 +3393,13 @@ packages:
     resolution: {integrity: sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==}
     dev: true
 
-  /ts-api-utils@1.0.3(typescript@5.3.2):
+  /ts-api-utils@1.0.3(typescript@5.3.3):
     resolution: {integrity: sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==}
     engines: {node: '>=16.13.0'}
     peerDependencies:
       typescript: '>=4.2.0'
     dependencies:
-      typescript: 5.3.2
+      typescript: 5.3.3
     dev: true
 
   /tslib@2.6.2:
@@ -3451,8 +3433,8 @@ packages:
     engines: {node: '>=12.20'}
     dev: true
 
-  /typescript@5.3.2:
-    resolution: {integrity: sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==}
+  /typescript@5.3.3:
+    resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true
@@ -3629,7 +3611,7 @@ packages:
       jsdom:
         optional: true
     dependencies:
-      '@vitest/browser': 1.0.0-beta.4(vitest@1.0.0-beta.4)(webdriverio@8.24.6)
+      '@vitest/browser': 1.0.0-beta.4(vitest@1.0.0-beta.4)(webdriverio@8.26.0)
       '@vitest/expect': 1.0.0-beta.4
       '@vitest/runner': 1.0.0-beta.4
       '@vitest/snapshot': 1.0.0-beta.4
@@ -3637,7 +3619,7 @@ packages:
       '@vitest/ui': 1.0.0-beta.4(vitest@1.0.0-beta.4)
       '@vitest/utils': 1.0.0-beta.4
       acorn: 8.11.2
-      acorn-walk: 8.3.0
+      acorn-walk: 8.3.1
       cac: 6.7.14
       chai: 4.3.10
       debug: 4.3.4
@@ -3687,17 +3669,17 @@ packages:
     engines: {node: '>= 8'}
     dev: true
 
-  /webdriver@8.24.6:
-    resolution: {integrity: sha512-k5XI2/SHd/14h4ElPQH8EzSUXujZIGbBEi+3dTS2H457KFR5Q8QYfIazDs/YnEdooOp8b6Oe9N7qI99LP8K6bQ==}
+  /webdriver@8.24.12:
+    resolution: {integrity: sha512-03DQIClHoaAqTsmDkxGwo4HwHfkn9LzJ1wfNyUerzKg8DnyXeiT6ILqj6EXLfsvh5zddU2vhYGLFXSerPgkuOQ==}
     engines: {node: ^16.13 || >=18}
     dependencies:
-      '@types/node': 20.10.3
+      '@types/node': 20.10.4
       '@types/ws': 8.5.10
-      '@wdio/config': 8.24.6
-      '@wdio/logger': 8.16.17
-      '@wdio/protocols': 8.23.0
-      '@wdio/types': 8.24.2
-      '@wdio/utils': 8.24.6
+      '@wdio/config': 8.24.12
+      '@wdio/logger': 8.24.12
+      '@wdio/protocols': 8.24.12
+      '@wdio/types': 8.24.12
+      '@wdio/utils': 8.24.12
       deepmerge-ts: 5.1.0
       got: 12.6.1
       ky: 0.33.3
@@ -3708,8 +3690,8 @@ packages:
       - utf-8-validate
     dev: true
 
-  /webdriverio@8.24.6(typescript@5.3.2):
-    resolution: {integrity: sha512-gJMAJiErbXe/oFJbV+H9lXp9GPxnUgHrbtxkG6SCKQlk1zPFho9FZ3fQWl/ty84w5n9ZMhAdnQIfZM9aytxIBQ==}
+  /webdriverio@8.26.0(typescript@5.3.3):
+    resolution: {integrity: sha512-4HfYTB1khiNaCtJGWnFmm/T5O1KAEL9srpWvIjw2XOkTd53rJ8pKTEU0lr/YtAunOELqcTZeTxb7Y0zfLsEEww==}
     engines: {node: ^16.13 || >=18}
     peerDependencies:
       devtools: ^8.14.0
@@ -3717,30 +3699,30 @@ packages:
       devtools:
         optional: true
     dependencies:
-      '@types/node': 20.10.3
-      '@wdio/config': 8.24.6
-      '@wdio/logger': 8.16.17
-      '@wdio/protocols': 8.23.0
-      '@wdio/repl': 8.23.1
-      '@wdio/types': 8.24.2
-      '@wdio/utils': 8.24.6
+      '@types/node': 20.10.4
+      '@wdio/config': 8.24.12
+      '@wdio/logger': 8.24.12
+      '@wdio/protocols': 8.24.12
+      '@wdio/repl': 8.24.12
+      '@wdio/types': 8.24.12
+      '@wdio/utils': 8.24.12
       archiver: 6.0.1
       aria-query: 5.3.0
       css-shorthand-properties: 1.1.1
       css-value: 0.0.1
-      devtools-protocol: 0.0.1213968
+      devtools-protocol: 0.0.1233178
       grapheme-splitter: 1.0.4
-      import-meta-resolve: 3.1.1
+      import-meta-resolve: 4.0.0
       is-plain-obj: 4.1.0
       lodash.clonedeep: 4.5.0
       lodash.zip: 4.2.0
       minimatch: 9.0.3
-      puppeteer-core: 20.9.0(typescript@5.3.2)
+      puppeteer-core: 20.9.0(typescript@5.3.3)
       query-selector-shadow-dom: 1.0.1
       resq: 1.11.0
       rgb2hex: 0.2.5
       serialize-error: 11.0.3
-      webdriver: 8.24.6
+      webdriver: 8.24.12
     transitivePeerDependencies:
       - bufferutil
       - encoding


### PR DESCRIPTION
Specifically:
- @stylistic/eslint-plugin-js: v1.5.0
- webdriverio: v8.26.0

We're staying revlocked to vite 4.5.1 and vitest, et. al. 1.0.0-beta.4 until https://github.com/vitest-dev/vitest/pull/4692 lands. Until then, the guidance added to README.md will allow usage of that fix and other Vitest improvements until they're officially released.