### PR TITLE
Frontend touch ups

### DIFF
--- a/strcalc/src/main/frontend/components/placeholder.js
+++ b/strcalc/src/main/frontend/components/placeholder.js
@@ -18,14 +18,8 @@
 import Template from './placeholder.hbs'
 
 export default class Placeholder {
-  #document
-
-  constructor(document) {
-    this.#document = document
-  }
-
   init() {
-    this.#document.querySelector('#app').innerHTML = Template({
+    document.querySelector('#app').innerHTML = Template({
       message: 'Hello, World!',
       url: 'https://en.wikipedia.org/wiki/%22Hello,_World!%22_program'
     })

--- a/strcalc/src/main/frontend/main.test.js
+++ b/strcalc/src/main/frontend/main.test.js
@@ -8,15 +8,15 @@ import { describe, afterEach, expect, test } from 'vitest'
 import { PageLoader } from './test-helpers.js'
 
 describe('String Calculator UI', () => {
-  let loader = new PageLoader('/strcalc')
+  const loader = new PageLoader('/strcalc')
 
   afterEach(() => loader.closeAll())
 
   describe('initial state', () => {
     test('contains the "Hello, World!" placeholder', async () => {
-      let { document } = await loader.load('index.html')
+      const { document } = await loader.load('index.html')
 
-      let e = document.querySelector('#app .placeholder a')
+      const e = document.querySelector('#app .placeholder a')
 
       expect(e.textContent).toContain('Hello, World!')
       expect(e.href).toContain('%22Hello,_World!%22')

--- a/strcalc/src/main/frontend/test-helpers.js
+++ b/strcalc/src/main/frontend/test-helpers.js
@@ -72,12 +72,11 @@ class BrowserPageLoader {
   async load(basePath, pagePath) {
     const w = this.#window.open(`${basePath}/${pagePath}`)
     return new Promise(resolve => {
-      w.addEventListener('load', () => {
+      const listener = () => {
         this.#setCoverageStore(w)
-        resolve({
-          window: w, document: w.document, close() { w.close() }
-        })
-      })
+        resolve({window: w, document: w.document, close() {w.close()}})
+      }
+      w.addEventListener('load', listener, {once: true})
     })
   }
 

--- a/strcalc/src/main/frontend/test-helpers.js
+++ b/strcalc/src/main/frontend/test-helpers.js
@@ -35,8 +35,8 @@ export class PageLoader {
       throw new Error(`${msg}"${pagePath}"`)
     }
 
-    let impl = await PageLoader.getImpl()
-    let page = await impl.load(this.#basePath, pagePath)
+    const impl = await PageLoader.getImpl()
+    const page = await impl.load(this.#basePath, pagePath)
 
     this.#loaded.push(page)
     return page
@@ -56,7 +56,7 @@ export class PageLoader {
       return this.#impl = new BrowserPageLoader(globalThis.window)
     }
 
-    let {JSDOM} = await import('jsdom')
+    const {JSDOM} = await import('jsdom')
     return this.#impl = new JsdomPageLoader(JSDOM, importModulesDynamically)
   }
 }
@@ -70,7 +70,7 @@ class BrowserPageLoader {
 
   // Loads a page and returns {window, document, close() } using the browser.
   async load(basePath, pagePath) {
-    let w = this.#window.open(`${basePath}/${pagePath}`)
+    const w = this.#window.open(`${basePath}/${pagePath}`)
     return new Promise(resolve => {
       w.addEventListener('load', () => {
         this.#setCoverageStore(w)
@@ -137,10 +137,10 @@ class JsdomPageLoader {
   // again. This enables (most) modules that register listeners for those
   // events to behave as expected in JSDOM based tests.
   async load(_, pagePath) {
-    let { window } = await this.#JSDOM.fromFile(
+    const { window } = await this.#JSDOM.fromFile(
       pagePath, {resources: 'usable', runScripts: 'dangerously'}
     )
-    let document = window.document
+    const document = window.document
 
     // Originally this function returned the result object directly, not
     // wrapped in the `done` Promise. This was because, for the original
@@ -251,7 +251,7 @@ class JsdomPageLoader {
 
   #importModulesPromise(window, document) {
     return new Promise(resolve => {
-      let importModules = async () => {
+      const importModules = async () => {
         // The JSDOM docs advise against setting global properties, but we don't
         // have another option given the module may access window and/or
         // document.
@@ -283,7 +283,7 @@ class JsdomPageLoader {
         // For the same reason, we fire the 'load' event again as well. When
         // that listener executes, we can finally reset the global.window and
         // global.document variables.
-        let resetGlobals = () => resolve(
+        const resetGlobals = () => resolve(
           global.window = global.document = undefined
         )
         window.addEventListener('load', resetGlobals, {once: true})
@@ -309,6 +309,6 @@ class JsdomPageLoader {
  * @returns {Promise}  a Promise resolved after importing all JS modules in doc
  */
 function importModulesDynamically(doc) {
-  let modules = doc.querySelectorAll('script[type="module"]')
+  const modules = doc.querySelectorAll('script[type="module"]')
   return Promise.all(Array.from(modules).map(m => import(m.src)))
 }

--- a/strcalc/src/main/frontend/vite.config.js
+++ b/strcalc/src/main/frontend/vite.config.js
@@ -21,7 +21,8 @@ export default defineConfig({
     handlebarsPrecompiler({ helpers: ['components/helpers.js'] })
   ],
   build: {
-    outDir: buildDir('webapp')
+    outDir: buildDir('webapp'),
+    sourcemap: true
   },
   css: {
     devSourcemap: true


### PR DESCRIPTION
## [s/let/const/g](https://github.com/mbland/tomcat-servlet-testing-example/commit/469ca9d176aaa078ce01db49e5c25d4f89063bc2)

Since `const` means the variable won't get reassigned, let's use it everywhere.

## [test-helpers.js: set window.addEventListener once](https://github.com/mbland/tomcat-servlet-testing-example/commit/76e9234f57645ad9185ab32142e8de457e8d19e3)

Now the BrowserPageLoader ensures that the window's 'load' event listener is configured to fire only once. Also hoisted the arrow function expression out of the addEventListener() argument list for readability.

## [Frontend: Depend on global document, not #this.doc](https://github.com/mbland/tomcat-servlet-testing-example/commit/49ff7eb90925426e98657e6490e2f87b813939d6)

After thinking about it, these components expect to execute in an environment with `window` and `document` available. Requiring every component to explicitly have `window` and `document` injected seems a bit onerous and impractical. It's easy enough to stub out these global objects as required.

## [Enable Vite to produce sourcemaps by default](https://github.com/mbland/tomcat-servlet-testing-example/commit/41d6d1d90a95a5024a113c9eac6e5409566e1171) 

Normally this should be controlled by an environment variable. For now, since this is a teaching project, we'll set it unconditionally to true.