### PR TITLE
Undo part of rollup plugin source map tweak

### DIFF
--- a/strcalc/src/main/frontend/rollup-plugin-handlebars-precompiler.js
+++ b/strcalc/src/main/frontend/rollup-plugin-handlebars-precompiler.js
@@ -106,7 +106,8 @@ class PluginImpl {
     this.#compilerOpts = (id) => ({ srcName: id, ...compilerOpts })
     this.#adjustSourceMap = function adjustSourceMap(map, numLinesBeforeTmpl) {
       const parsed = JSON.parse(map)
-      return { mappings: `${';'.repeat(numLinesBeforeTmpl)}${parsed.mappings}` }
+      parsed.mappings = `${';'.repeat(numLinesBeforeTmpl)}${parsed.mappings}`
+      return parsed
     }
 
     // This specifies that source maps can be disabled via "sourceMap: false":


### PR DESCRIPTION
The part of the change from #35 that updated #adjustSourceMap to only return the `mappings` property broke Handlebars source maps. Apparently while Rollup only "cares" about the `mappings` property, it needs to pass through the rest of the properties from Handlebars.