### PR TITLE
Return Handlebars template as HTMLCollection

### DIFF
--- a/strcalc/src/main/frontend/components/placeholder.js
+++ b/strcalc/src/main/frontend/components/placeholder.js
@@ -19,9 +19,9 @@ import Template from './placeholder.hbs'
 
 export default class Placeholder {
   init() {
-    document.querySelector('#app').innerHTML = Template({
+    document.querySelector('#app').append(...Template({
       message: 'Hello, World!',
       url: 'https://en.wikipedia.org/wiki/%22Hello,_World!%22_program'
-    })
+    }))
   }
 }


### PR DESCRIPTION
It became apparently quickly that converting the raw string returned by Template() (from Handlebars.template()) would be a chore. Now the desire of the mixmaxhq/rollup-plugin-handlebars-plus devs to use JQuery to do this automatically makes more sense.

Fortunately, all modern browsers now support the <template> element:

- https://developer.mozilla.org/docs/Web/HTML/Element/template
- https://caniuse.com/?search=%3Ctemplate%3E

So now, rollup-plugin-handlebars-precompiler will always emit the helper module, which now exports the new TemplateElements() function, which is based on:

- https://stackoverflow.com/a/35385518

The function generated by Handlebars.template() is now exported as RawTemplate(). The new Template() calls RawTemplate(), passes the result to TemplateElements(), and returns the resulting HTMLCollection.