### PR TITLE
Make emitted Handlebars plugin code smaller

### DIFF
--- a/strcalc/src/main/frontend/rollup-plugin-handlebars-precompiler.js
+++ b/strcalc/src/main/frontend/rollup-plugin-handlebars-precompiler.js
@@ -57,7 +57,7 @@ const DEFAULT_PARTIAL_PATH = (partialName, importerPath) => {
 const PLUGIN_ID = `\0${PLUGIN_NAME}`
 const HANDLEBARS_PATH = 'handlebars/lib/handlebars.runtime'
 const IMPORT_HANDLEBARS = `import Handlebars from '${HANDLEBARS_PATH}'`
-const IMPORT_HELPERS = `import TemplateElements from '${PLUGIN_ID}'`
+const IMPORT_HELPERS = `import Render from '${PLUGIN_ID}'`
 
 // https://github.com/handlebars-lang/handlebars.js/blob/master/docs/compiler-api.md
 class PartialCollector extends Handlebars.Visitor {
@@ -128,11 +128,11 @@ class PluginImpl {
       ...helpers.map((h, i) => `import registerHelpers${i} from './${h}'`),
       ...helpers.map((_, i) => `registerHelpers${i}(Handlebars)`),
       // Inspired by: https://stackoverflow.com/a/35385518
-      'export default function TemplateElements(renderedTemplate) {',
+      'export default (rawTemplate) => ((context, options) => {',
       '  const t = document.createElement(\'template\')',
-      '  t.innerHTML = renderedTemplate',
+      '  t.innerHTML = rawTemplate(context, options)',
       '  return t.content.children',
-      '}'
+      '})'
     ].join('\n')
   }
 
@@ -154,9 +154,7 @@ class PluginImpl {
     ]
     const afterTmpl = [
       ')',
-      'export default function Template(context, options) {',
-      '  return TemplateElements(RawTemplate(context, options))',
-      '}',
+      'export default Render(RawTemplate)',
       ...(this.#isPartial(id) ? [ this.#partialRegistration(id) ] : [])
     ]
     return {


### PR DESCRIPTION
The helpers module now exports an (unnamed) default function that takes a function created by Handlebars.template and wraps it in a new function. The returned function both executes the input function and renders its result as an HTMLCollection.

This doesn't change observable behavior, but makes the code emitted for each Handlebars template module slightly smaller.