### PR TITLE
Improve JsdomPageLoader robustness, invoke m.start

### DIFF
--- a/strcalc/src/main/frontend/components/placeholder.js
+++ b/strcalc/src/main/frontend/components/placeholder.js
@@ -18,7 +18,13 @@
 import Template from './placeholder.hbs'
 
 export default class Placeholder {
-  init() {
+
+  /**
+   * Initializes the Placeholder within the document.
+   * @param {Window} window - the browser window object
+   * @param {Document} document - a Document or DocumentFragment
+   */
+  init(window, document) {
     document.querySelector('#app').append(...Template({
       message: 'Hello, World!',
       url: 'https://en.wikipedia.org/wiki/%22Hello,_World!%22_program'

--- a/strcalc/src/main/frontend/init.js
+++ b/strcalc/src/main/frontend/init.js
@@ -17,8 +17,9 @@ import Placeholder from './components/placeholder'
  *
  * This is a teaching example that contains minimal business logic in order to
  * demonstrate how to design much larger applications for testability.
- * @param {Document} document The DOM window.document object
+ * @param {Window} window - the browser window object
+ * @param {Document} document - a Document or DocumentFragment
  */
-export default function initApp(document) {
-  new Placeholder(document).init()
+export default function initApp(window, document) {
+  new Placeholder().init(window, document)
 }

--- a/strcalc/src/main/frontend/main.js
+++ b/strcalc/src/main/frontend/main.js
@@ -17,4 +17,20 @@
  */
 import initApp from './init'
 
-document.addEventListener('DOMContentLoaded', () => initApp(document))
+/**
+ * Calls the application initializer with the global window and document.
+ *
+ * In addition to demonstrating how ECMAScript modules are linked together,
+ * this shows how to introduce a shim between globalThis and the initApp()
+ * function. Most tests can then call initApp() directly, and only two tests are
+ * needed to validate that start() is or isn't called.
+ * @param {Window} window - the browser window object
+ * @param {Document} document - a Document or DocumentFragment
+ */
+export default function start(window, document) {
+  document.addEventListener('DOMContentLoaded', () => initApp(window, document))
+}
+
+if (globalThis.window !== undefined) {
+  start(globalThis.window, globalThis.window.document)
+}


### PR DESCRIPTION
In addition to the (incomplete, with more forthcoming) JSDoc updates, these changes aim to achieve two goals:

1. Increase the changes that the dynamic import of ECMAScript modules from a JSDOM doc will succeed if event listeners access window and document directly.

   This is why the registering of resetGlobals() as a 'load' event listener takes place after the manual DOMContentLoaded dispatch.

2. Support, encourage, and illustrate a module design schema that takes window and document arguments as entry point arguments.

   This why importModulesDynamically() now attempts to invoke a default function(window, document) exported by each module. The main.js module, initApp(), and Placeholder.init() now reflect this design.

The new implementation comments explain the details behind both of these goals. A lot of the implementation comment content will likely end up in the JSDoc or a README at some point.