### PR TITLE
Undo import(module).start() convention

### DIFF
--- a/strcalc/src/main/frontend/test-helpers.js
+++ b/strcalc/src/main/frontend/test-helpers.js
@@ -339,9 +339,8 @@ class JsdomPageLoader {
  */
 function importModulesDynamically(window, doc) {
   const modules = doc.querySelectorAll('script[type="module"]')
-  return Promise.all(Array.from(modules).map(async m => {
-    if (m.src === undefined) return
-    const { default: start } = await import(m.src)
-    return typeof start === 'function' ? start(window, doc) : start
-  }))
+  return Promise.all(Array.from(modules)
+    .filter(m => m.src !== undefined)
+    .map(async m => await import(m.src))
+  )
 }


### PR DESCRIPTION
This reverts part of commit 6ae34c26a1263f7232fbb3447c90251430c346d4.

After further consideration, I realized that the .start() convention didn't really provide much use. I was thinking it would encourage thinking of window and document as arguments injected into the module. However, modules can be designed that way and tested directly without this idiom.

I did, however, take the liberty to filter out any <script type="module"> elements without a `src` attribute, for safety's sake.