### PR TITLE
Add initApp test, fragment helper, page object

### DIFF
--- a/strcalc/src/main/frontend/init.test.js
+++ b/strcalc/src/main/frontend/init.test.js
@@ -4,19 +4,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-import { describe, afterEach, expect, test } from 'vitest'
-import { PageLoader } from './test-helpers.js'
+import initApp from './init'
+import { describe, expect, test } from 'vitest'
+import { fragment } from './test-helpers.js'
 import StringCalculatorPage from './test-page.js'
 
-describe('String Calculator UI on initial page load', () => {
-  const loader = new PageLoader('/strcalc')
-  afterEach(() => loader.closeAll())
-
+// @vitest-environment jsdom
+describe('initial state after calling initApp', () => {
   test('contains the "Hello, World!" placeholder', async () => {
-    const { document } = await loader.load('index.html')
+    const document = fragment('<div id="app"></div>')
+
+    initApp(window, document)
 
     const e = new StringCalculatorPage(document).getPlaceholder()
     expect(e.textContent).toContain('Hello, World!')
     expect(e.href).toContain('%22Hello,_World!%22')
   })
 })
+

--- a/strcalc/src/main/frontend/test-helpers.js
+++ b/strcalc/src/main/frontend/test-helpers.js
@@ -11,6 +11,20 @@
  */
 
 /**
+ * Produces a DocumentFragment from an HTML string.
+ *
+ * Useful for running tests on Document-like objects that don't impact the
+ * actual global Document.
+ * @param {string} innerHtml - HTML from which to produce a DocumentFragment
+ * @returns {DocumentFragment} - DocumentFragment containing innerHtml elements
+ */
+export function fragment(innerHtml) {
+  const t = document.createElement('template')
+  t.innerHTML = innerHtml
+  return t.content
+}
+
+/**
  * Enables tests to load page URLs both in the browser and in Node using JSDom.
  */
 export class PageLoader {

--- a/strcalc/src/main/frontend/test-page.js
+++ b/strcalc/src/main/frontend/test-page.js
@@ -1,0 +1,25 @@
+/* eslint-env browser */
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/**
+ * Represents the StringCalculator web page.
+ *
+ * Follows the Page Object pattern from the Selenium WebDriver documentation,
+ * though we're using the DOM directly rather than Selenium.
+ * @see https://www.selenium.dev/documentation/test_practices/design_strategies/
+ */
+export default class StringCalculatorPage {
+  document
+
+  constructor(doc) {
+    this.document = doc
+  }
+
+  getPlaceholder() {
+    return this.document.querySelector('#app .placeholder a')
+  }
+}


### PR DESCRIPTION
The initApp() test uses the jsdom environment provided by Vitest:

- https://vitest.dev/guide/environment.html

The fragment() test helper works as-is in both the jsdom and browser environments. The StringCalculatorPage object follows the Page Object pattern from the Selenium WebDriver docs, even though we're not using Selenium here:

- https://www.selenium.dev/documentation/test_practices/design_strategies/

---

I settled on this after days of trying to figure out how to execute JS Modules on a JSDOM instance directly. See:

- commit 86ac76f6acc9522f5b271f0ea9096fc5cbb50730
- commit 9c87cbfa82b4bc28306fdcaeaed45885e314def6
- commit d55f78da1f06ea1a4b0f88be58d0be9e950ec864

I finally realized that if what I wanted to do was so difficult, maybe there was a better way. So this change keeps the PageLoader-based test from before, to make sure initApp executes on DOMContentLoaded. But for the new initApp test, as for the upcoming tests for other modules, using the jsdom environment will suffice.

I was also pleased to discover that `vitest --browser` will do the right thing and _not_ load the jsdom environment in the browser. So tests using the jsdom environment will already execute in the browser for free. (Perhaps there are features which would require a workaround between the jsdom and browser environments, but I haven't encountered them yet.)