### PR TITLE
Make Placeholder.init() static, remove main.start

### DIFF
--- a/strcalc/src/main/frontend/components/placeholder.js
+++ b/strcalc/src/main/frontend/components/placeholder.js
@@ -24,7 +24,7 @@ export default class Placeholder {
    * @param {Window} window - the browser window object
    * @param {Document} document - a Document or DocumentFragment
    */
-  init(window, document) {
+  static init(window, document) {
     document.querySelector('#app').append(...Template({
       message: 'Hello, World!',
       url: 'https://en.wikipedia.org/wiki/%22Hello,_World!%22_program'

--- a/strcalc/src/main/frontend/init.js
+++ b/strcalc/src/main/frontend/init.js
@@ -21,5 +21,5 @@ import Placeholder from './components/placeholder'
  * @param {Document} document - a Document or DocumentFragment
  */
 export default function initApp(window, document) {
-  new Placeholder().init(window, document)
+  Placeholder.init(window, document)
 }

--- a/strcalc/src/main/frontend/main.js
+++ b/strcalc/src/main/frontend/main.js
@@ -20,17 +20,11 @@ import initApp from './init'
 /**
  * Calls the application initializer with the global window and document.
  *
- * In addition to demonstrating how ECMAScript modules are linked together,
- * this shows how to introduce a shim between globalThis and the initApp()
- * function. Most tests can then call initApp() directly, and only two tests are
- * needed to validate that start() is or isn't called.
+ * Wraps the initApp() call in a DOMContentLoaded event listener.
+ * - main.test.js uses PageLoader to validate that initApp() fires on
+ *   DOMContentLoaded.
+ * - init.test.js tests the initApp() method directly.
  * @param {Window} window - the browser window object
  * @param {Document} document - a Document or DocumentFragment
  */
-export default function start(window, document) {
-  document.addEventListener('DOMContentLoaded', () => initApp(window, document))
-}
-
-if (globalThis.window !== undefined) {
-  start(globalThis.window, globalThis.window.document)
-}
+document.addEventListener('DOMContentLoaded', () => initApp(window, document))


### PR DESCRIPTION
After thinking about it, it doesn't make sense to instantiate a component object with on internal state to invoke what could be a static method. If a componenent needed to create a stateful object to manage interactions, its static init() could take care of that.

Also removes the start() function from main.js, which should've been removed in commit 366d9bc1027a929b0bd8c62c9ee0bdbd422b367b from #41.