### PR TITLE
Embed fragment() call in StringCalculatorPage

### DIFF
--- a/strcalc/src/main/frontend/init.test.js
+++ b/strcalc/src/main/frontend/init.test.js
@@ -6,17 +6,16 @@
  */
 import initApp from './init'
 import { describe, expect, test } from 'vitest'
-import { fragment } from './test-helpers.js'
-import StringCalculatorPage from './test-page.js'
+import StringCalculatorPage from './test-page'
 
 // @vitest-environment jsdom
 describe('initial state after calling initApp', () => {
   test('contains the "Hello, World!" placeholder', async () => {
-    const document = fragment('<div id="app"></div>')
+    const page = new StringCalculatorPage()
 
-    initApp(window, document)
+    initApp(window, page.document)
 
-    const e = new StringCalculatorPage(document).getPlaceholder()
+    const e = page.placeholder()
     expect(e.textContent).toContain('Hello, World!')
     expect(e.href).toContain('%22Hello,_World!%22')
   })

--- a/strcalc/src/main/frontend/main.test.js
+++ b/strcalc/src/main/frontend/main.test.js
@@ -5,8 +5,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 import { describe, afterEach, expect, test } from 'vitest'
-import { PageLoader } from './test-helpers.js'
-import StringCalculatorPage from './test-page.js'
+import { PageLoader } from './test-helpers'
+import StringCalculatorPage from './test-page'
 
 describe('String Calculator UI on initial page load', () => {
   const loader = new PageLoader('/strcalc')
@@ -15,7 +15,7 @@ describe('String Calculator UI on initial page load', () => {
   test('contains the "Hello, World!" placeholder', async () => {
     const { document } = await loader.load('index.html')
 
-    const e = new StringCalculatorPage(document).getPlaceholder()
+    const e = new StringCalculatorPage(document).placeholder()
     expect(e.textContent).toContain('Hello, World!')
     expect(e.href).toContain('%22Hello,_World!%22')
   })

--- a/strcalc/src/main/frontend/test-page.js
+++ b/strcalc/src/main/frontend/test-page.js
@@ -5,6 +5,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+import { fragment } from './test-helpers'
+
 /**
  * Represents the StringCalculator web page.
  *
@@ -14,12 +16,12 @@
  */
 export default class StringCalculatorPage {
   document
+  #select
 
   constructor(doc) {
-    this.document = doc
+    this.document = doc !== undefined ? doc : fragment('<div id="app"></div>')
+    this.#select = selector => this.document.querySelector(`#app ${selector}`)
   }
 
-  getPlaceholder() {
-    return this.document.querySelector('#app .placeholder a')
-  }
+  placeholder() { return this.#select('.placeholder a') }
 }


### PR DESCRIPTION
This prevents the need for every test to call fragment() with the same argument.

Also renamed getPlaceholder() to placeholder() and removed the '.js' suffix from import paths.