### PR TITLE
Pass the <div id="app"> to initApp()

### DIFF
--- a/strcalc/src/main/frontend/components/init.js
+++ b/strcalc/src/main/frontend/components/init.js
@@ -19,7 +19,8 @@ import Placeholder from './placeholder'
  * demonstrate how to design much larger applications for testability.
  * @param {Window} window - the browser window object
  * @param {Document} document - a Document or DocumentFragment
+ * @param {Element} appElem - the parent Element containing all app components
  */
-export default function initApp(window, document) {
-  Placeholder.init(window, document)
+export default function initApp(window, document, appElem) {
+  Placeholder.init(window, document, appElem)
 }

--- a/strcalc/src/main/frontend/components/init.test.js
+++ b/strcalc/src/main/frontend/components/init.test.js
@@ -13,7 +13,7 @@ describe('initial state after calling initApp', () => {
   test('contains the "Hello, World!" placeholder', async () => {
     const page = new StringCalculatorPage()
 
-    initApp(window, page.document)
+    initApp(window, page.document, page.appElem)
 
     const e = page.placeholder()
     expect(e.textContent).toContain('Hello, World!')

--- a/strcalc/src/main/frontend/components/placeholder.js
+++ b/strcalc/src/main/frontend/components/placeholder.js
@@ -23,9 +23,10 @@ export default class Placeholder {
    * Initializes the Placeholder within the document.
    * @param {Window} window - the browser window object
    * @param {Document} document - a Document or DocumentFragment
+   * @param {Element} appElem - the parent Element containing all app components
    */
-  static init(window, document) {
-    document.querySelector('#app').appendChild(Template({
+  static init(window, document, appElem) {
+    appElem.appendChild(Template({
       message: 'Hello, World!',
       url: 'https://en.wikipedia.org/wiki/%22Hello,_World!%22_program'
     }))

--- a/strcalc/src/main/frontend/main.js
+++ b/strcalc/src/main/frontend/main.js
@@ -24,7 +24,7 @@ import initApp from './components/init'
  * - main.test.js uses PageLoader to validate that initApp() fires on
  *   DOMContentLoaded.
  * - init.test.js tests the initApp() method directly.
- * @param {Window} window - the browser window object
- * @param {Document} document - a Document or DocumentFragment
  */
-document.addEventListener('DOMContentLoaded', () => initApp(window, document))
+document.addEventListener('DOMContentLoaded', () => {
+  initApp(window, document, document.querySelector('#app'))
+})

--- a/strcalc/src/main/frontend/test/page.js
+++ b/strcalc/src/main/frontend/test/page.js
@@ -16,11 +16,13 @@ import { fragment } from './helpers'
  */
 export default class StringCalculatorPage {
   document
+  appElem
   #select
 
   constructor(doc) {
     this.document = doc !== undefined ? doc : fragment('<div id="app"></div>')
-    this.#select = selector => this.document.querySelector(`#app ${selector}`)
+    this.appElem = this.document.querySelector('#app')
+    this.#select = s => this.document.querySelector(`#${this.appElem.id} ${s}`)
   }
 
   placeholder() { return this.#select('.placeholder a') }


### PR DESCRIPTION
Now main.js retrieves the top level element and passes it to initApp(), which then gets passed to the other components.

---

While still thinking about the &lt;form&gt; + DocumentFragment problem, it occurred to me that not every component should need to call document.querySelector('#app'). I'm also currently expecting the &lt;form&gt; solution I come up with to require creating elements on the main DOM instead of a DocumentFragment.

Plus, if we ever want to change that ID, or use a class name, etc., we'd have to update every querySelector() call. This new architecture eliminates that particular problem.