### PR TITLE
Pass initApp() params as object

### DIFF
--- a/strcalc/src/main/frontend/components/init.js
+++ b/strcalc/src/main/frontend/components/init.js
@@ -17,10 +17,9 @@ import Placeholder from './placeholder'
  *
  * This is a teaching example that contains minimal business logic in order to
  * demonstrate how to design much larger applications for testability.
- * @param {Window} window - the browser window object
- * @param {Document} document - a Document or DocumentFragment
- * @param {Element} appElem - the parent Element containing all app components
+ * @param {object} params - parameters made available to all initializers
+ * @param {Element} params.appElem - parent Element containing all components
  */
-export default function initApp(window, document, appElem) {
-  Placeholder.init(window, document, appElem)
+export default function initApp(params) {
+  [Placeholder].forEach(c => c.init(params))
 }

--- a/strcalc/src/main/frontend/components/init.test.js
+++ b/strcalc/src/main/frontend/components/init.test.js
@@ -15,7 +15,7 @@ describe('initial state after calling initApp', () => {
   test('contains the "Hello, World!" placeholder', async () => {
     const page = StringCalculatorPage.new('app-init')
 
-    initApp(window, document, page.appElem, {})
+    initApp({ window, document, appElem: page.appElem })
 
     const e = page.placeholder()
     expect(e.textContent).toContain('Hello, World!')

--- a/strcalc/src/main/frontend/components/placeholder.js
+++ b/strcalc/src/main/frontend/components/placeholder.js
@@ -20,11 +20,10 @@ import Template from './placeholder.hbs'
 export default class Placeholder {
   /**
    * Initializes the Placeholder within the document.
-   * @param {Window} window - the browser window object
-   * @param {Document} document - a Document or DocumentFragment
-   * @param {Element} appElem - the parent Element containing all app components
+   * @param {object} params - parameters made available to all initializers
+   * @param {Element} params.appElem - parent Element containing all components
    */
-  static init(window, document, appElem) {
+  static init({ appElem }) {
     appElem.appendChild(Template({
       message: 'Hello, World!',
       url: 'https://en.wikipedia.org/wiki/%22Hello,_World!%22_program'

--- a/strcalc/src/main/frontend/main.js
+++ b/strcalc/src/main/frontend/main.js
@@ -25,6 +25,11 @@ import initApp from './components/init'
  *   DOMContentLoaded.
  * - init.test.js tests the initApp() method directly.
  */
-document.addEventListener('DOMContentLoaded', () => {
-  initApp(window, document, document.querySelector('#app'))
-})
+document.addEventListener(
+  'DOMContentLoaded',
+  () => {
+    const appElem = document.querySelector('#app')
+    initApp({ appElem })
+  },
+  { once: true }
+)

--- a/strcalc/src/main/frontend/test/helpers.js
+++ b/strcalc/src/main/frontend/test/helpers.js
@@ -11,20 +11,6 @@
  */
 
 /**
- * Produces a DocumentFragment from an HTML string.
- *
- * Useful for running tests on Document-like objects that don't impact the
- * actual global Document.
- * @param {string} innerHtml - HTML from which to produce a DocumentFragment
- * @returns {DocumentFragment} - DocumentFragment containing innerHtml elements
- */
-export function fragment(innerHtml) {
-  const t = document.createElement('template')
-  t.innerHTML = innerHtml
-  return t.content
-}
-
-/**
  * Enables tests to load page URLs both in the browser and in Node using JSDom.
  */
 export class PageLoader {


### PR DESCRIPTION
Now all parameters that initApp() may pass through to each individual component's init() function are bundled into a single object.

Other small but significant changes:

- Removes window and document from the parameter list for now, as there's no components that need to inject them.

- Sets up a list of components in initApp() so that it can call each component's init() via forEach(). This eliminates the need to add a new line for each init() call for each added component.

- Sets initApp() to run only once on DOMContentLoaded.

- Removes the now unused fragment() test helper (should've been part of commit 5f2a91735b9ccd4a89390b4be4522e6c57b9ac64 from #51).

---

While adding the Calculator component, it became apparent that adding more params to main.js and initApp() to pass through to init() was becoming unwieldy. This solution makes future extension easier and the code cleaner while decoupling component initializer signatures from one another.