### PR TITLE
Add resolvedUrl() helper, apply to form action

### DIFF
--- a/strcalc/src/main/frontend/components/request.test.js
+++ b/strcalc/src/main/frontend/components/request.test.js
@@ -6,6 +6,7 @@
  */
 import { post, postForm, postOptions } from './request'
 import { afterEach, describe, expect, test, vi } from 'vitest'
+import { resolvedUrl } from '../test/helpers'
 
 // @vitest-environment jsdom
 describe('Request', () => {
@@ -70,7 +71,7 @@ describe('Request', () => {
       // causes form.action to become `#{document.location.origin}/fetch` in
       // every environment.
       const form = document.createElement('form')
-      const resolvedAction = `${document.location.origin}/fetch`
+      const resolvedAction = resolvedUrl('./fetch')
       const res = { foo: 'bar' }
       const fetchStub = setupFetchStub(JSON.stringify(res))
 

--- a/strcalc/src/main/frontend/test/helpers.js
+++ b/strcalc/src/main/frontend/test/helpers.js
@@ -11,6 +11,15 @@
  */
 
 /**
+ * Resolves URL path against the current document location
+ * @param {string} path - path to resolve
+ * @returns {string} - the result of resolving path against document.location
+ */
+export function resolvedUrl(path) {
+  return new URL(path, document.location.href).toString()
+}
+
+/**
  * Enables tests to load page URLs both in the browser and in Node using JSDom.
  */
 export class PageLoader {


### PR DESCRIPTION
This new resolvedUrl() helper should make resolution of application URLs more adaptable to different host document URLs, beyond prepending document.location.origin.