### PR TITLE
Add implementation selector to web form

### DIFF
--- a/strcalc/src/main/frontend/components/calculator.hbs
+++ b/strcalc/src/main/frontend/components/calculator.hbs
@@ -4,10 +4,16 @@
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
 --}}
 <form action="{{ apiUrl }}" method="post">
-  <label for="numbers" name="numbersLabel" id="numbersLabel">
-      Enter the string of numbers to add:
-  </label>
+  <label for="numbers">Enter the string of numbers to add:</label>
   <input type="text" name="numbers" id="numbers" required />
+  <fieldset class="impl">
+    <p>Select which implementation to use:</p>
+    {{#each implementations}}{{#with this}}
+      <label for="impl-{{ value }}">{{ label }}</label>
+      <input type="radio" id="impl-{{ value }}" name="impl" value="{{ value }}"
+       {{#if @first}}checked{{/if}}/>{{#unless @last}}<br/>{{/unless}}
+    {{/with}}{{/each}}
+  </fieldset>
   <input type="submit" name="numbersSubmit" id="numbersSubmit" value="Add" />
 </form>
 <div class="result"><p>The result will appear here.</p></div>

--- a/strcalc/src/main/frontend/components/calculator.js
+++ b/strcalc/src/main/frontend/components/calculator.js
@@ -15,10 +15,15 @@ export default class Calculator {
    * @param {Function} params.postForm - posts form data to API
    */
   init({ appElem, apiUrl, postForm }) {
-    const t = Template({ apiUrl })
+    const implementations = [
+      { label: 'Tomcat backend (Java)', value: 'java' },
+      { label: 'In-browser frontend (JavaScript)', value: 'javascript' }
+    ]
+    const t = Template({ apiUrl, implementations })
     const [ form, resultElem ] = t.children
 
     appElem.appendChild(t)
+    document.querySelector('#numbers').focus()
     form.addEventListener(
       'submit', e => Calculator.#submitRequest(e, resultElem, postForm)
     )

--- a/strcalc/src/main/frontend/style.css
+++ b/strcalc/src/main/frontend/style.css
@@ -58,7 +58,11 @@ input[type="text"] {
   outline: 0;
   border-radius: 5px;
   border: 1px solid;
-  padding: 2px 5px;
+  padding: 5px;
+}
+
+fieldset.impl p {
+  margin: 0;
 }
 
 input[type="submit"] {


### PR DESCRIPTION
Right now the selector doesn't have any effect, as Calculator still uses the Java backend unconditionally. Using the selector to switch implementations will come shortly.