### PR TITLE
Fix incorrect form.action due to incorrect base

### DIFF
--- a/strcalc/src/main/frontend/main.test.js
+++ b/strcalc/src/main/frontend/main.test.js
@@ -9,7 +9,7 @@ import { PageLoader } from './test/helpers'
 import StringCalculatorPage from './test/page'
 
 describe('String Calculator UI on initial page load', () => {
-  const loader = new PageLoader('/strcalc')
+  const loader = new PageLoader('/strcalc/')
   afterEach(() => loader.closeAll())
 
   test('contains the "Hello, World!" placeholder', async () => {

--- a/strcalc/src/main/frontend/test/helpers.js
+++ b/strcalc/src/main/frontend/test/helpers.js
@@ -29,9 +29,9 @@ export class PageLoader {
   #loaded
 
   constructor(basePath) {
-    if (!basePath.startsWith('/') || basePath.endsWith('/')) {
+    if (!basePath.startsWith('/') || !basePath.endsWith('/')) {
       const msg = 'basePath should start with \'/\' and ' +
-        'not end with \'/\', got: '
+        'end with \'/\', got: '
       throw new Error(`${msg}"${basePath}"`)
     }
     this.#basePath = basePath
@@ -79,7 +79,7 @@ class BrowserPageLoader {
 
   // Loads a page and returns {window, document, close() } using the browser.
   async load(basePath, pagePath) {
-    const w = this.#window.open(`${basePath}/${pagePath}`)
+    const w = this.#window.open(`${basePath}${pagePath}`)
     return new Promise(resolve => {
       const listener = () => {
         this.#setCoverageStore(w)

--- a/strcalc/src/main/frontend/vite.config.js
+++ b/strcalc/src/main/frontend/vite.config.js
@@ -20,7 +20,7 @@ export default defineConfig({
   // Remove process.env.VITEST hack once the following are resolved/merged:
   // - https://github.com/vitest-dev/vitest/issues/4686
   // - https://github.com/vitest-dev/vitest/pull/4692
-  base: process.env.VITEST ? undefined : '/strcalc',
+  base: process.env.VITEST ? undefined : '/strcalc/',
   plugins: [
     handlebarsPrecompiler({ helpers: ['components/helpers.js'] })
   ],


### PR DESCRIPTION
With the base URL '/strcalc', resolving the form action URL './add' against document.location.href produces the path '/add', which is incorrect.

With the base URL '/strcalc/', resolving './add' produces '/strcalc/add' as expected.

---

Writing a test for this directly is difficult. (At least, it is at the component level using Vitest; an end-to-end Selenium test would catch it.) Tying the form action URL to a specific absolute path would render the component and its tests brittle. Also, it seems that trying to import the config from vite.config.js into a test (to access the config.base value) breaks the Vitest loader somehow.

As a proxy for a test assertion, the PageLoader constructor now enforces that the base path ends with '/' (before it enforced that it _didn't_).