### PR TITLE
Add workflow_run.id to actions/download-artifact

### DIFF
--- a/.github/workflows/publish-test-results.yaml
+++ b/.github/workflows/publish-test-results.yaml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: test-results
+          run-id: ${{ github.event.workflow_run.id }}
 
       - name: Post test report
         uses: dorny/test-reporter@v1


### PR DESCRIPTION
The addition of actions/download-artifact@v4 to
publish-test-results.yaml in #66 still failed:

- https://github.com/mbland/tomcat-servlet-testing-example/actions/runs/7267779677/job/19802307107

What was interesting was the `run-id:` value from the "Download test results" step:

```text
  Run actions/download-artifact@v4
    with:
      name: test-results
      merge-multiple: false
      repository: mbland/tomcat-servlet-testing-example
      run-id: 7267779677
  Downloading single artifact
  Error: Unable to download artifact(s): Artifact not found for name:
    test-results
```

followed by this line from "Post test report":

```text
  Action was triggered by workflow_run: using SHA and RUN_ID from
  triggering workflow
```

So this change attempts to fix the breakage by adding `github.event.workflow_run.id` to the actions/download-artifact configuration.