### PR TITLE
Add github.token to actions/download-artifact

### DIFF
--- a/.github/workflows/publish-test-results.yaml
+++ b/.github/workflows/publish-test-results.yaml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: test-results
+          github-token: ${{ github.token }}
           run-id: ${{ github.event.workflow_run.id }}
 
       - name: Post test report


### PR DESCRIPTION
The addition of workflow_run.id in #67 wasn't enough. Tracing through the dorny/test-reporter code, I found that it was grabbing github.token as well. The actions/download-artifact README documentation now makes more sense:

```yaml
  # The GitHub token used to authenticate with the GitHub API. This is
  # required when downloading artifacts from a different repository or
  # from a different workflow run.
  # Optional. If unspecified, the action will download artifacts from
  # the current repo and the current workflow run.
  github-token:

  # The id of the workflow run where the desired download artifact was
  # uploaded from. If github-token is specified, this is the run that
  # artifacts will be downloaded from.
  # Optional. Default is ${{ github.run_id }}
  run-id:
```

Basically, I think both are needed here, based on what dorny/test-reporter appears to be doing.