### PR TITLE
Add actions/checkout to publish-test-results

### DIFF
--- a/.github/workflows/publish-test-results.yaml
+++ b/.github/workflows/publish-test-results.yaml
@@ -19,6 +19,16 @@ jobs:
   report:
     runs-on: ubuntu-latest
     steps:
+      # dorny/test-reporter has an `artifact:` attribute that will check out the
+      # repo and download test results automatically. However,
+      # dorny/test-reporter@v1 wasn't compatible with the bump to
+      # actions/upload-artifact@v4 in run-tests.yaml. So we manually check
+      # out the repo and download the results to avoid the rev lock.
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_commit.id }}
+
       - name: Download test results
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -14,7 +14,8 @@ jobs:
     name: "Run Tests"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out repository
+        uses: actions/checkout@v4
 
       - name: Set up Java
         uses: actions/setup-java@v4


### PR DESCRIPTION
The overall "Publish Test Results" run for #68 failed, but _after_ that change caused the "Download test results" step to pass:

- https://github.com/mbland/tomcat-servlet-testing-example/actions/runs/7268307692/job/19803882107

Tracing through the code, it seems that dorny/test-reporter does the following:

- When `artifact:` is specified, it will check out the repo at github.event.workflow_run.head_commit.id.
- When `artifact:` is _not_ specified, it assumes the repo is already present.

This should, hopefully, provide the last missing piece for the test reporter to run successfully.