### PR TITLE
Use top level .gitattributes for entire project

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,10 @@
-#
-# https://help.github.com/articles/dealing-with-line-endings/
-#
-# Linux start script should use lf
-/gradlew        text eol=lf
+# Ensure line endings remain LF on Windows, instead of getting
+# translated to CRLF. Otherwise, Bash chokes on \r characters.
+# - https://help.github.com/articles/dealing-with-line-endings/
+# - https://stackoverflow.com/a/47187309
+* text eol=lf
 
-# These are Windows script files and should use crlf
-*.bat           text eol=crlf
+# Windows-specific files use CRLF
+*.bat text eol=crlf
 
+gradle/wrapper/gradle-wrapper.jar binary

--- a/strcalc/src/main/frontend/.gitattributes
+++ b/strcalc/src/main/frontend/.gitattributes
@@ -1,5 +1,0 @@
-# Ensure line endings remain LF on Windows, instead of getting
-# translated to CRLF. Otherwise, Bash chokes on \r characters.
-# - https://help.github.com/articles/dealing-with-line-endings/
-# - https://stackoverflow.com/a/47187309
-* text eol=lf


### PR DESCRIPTION
I'd originally only set them for strcalc/src/main/frontend by mistake in commit e8aa28b53bc8d5fab160998da78f076847273c3d from #71.