### PR TITLE
Remove java.toolchain from build, fix Win arm64

### DIFF
--- a/strcalc/build.gradle.kts
+++ b/strcalc/build.gradle.kts
@@ -39,13 +39,6 @@ dependencies {
     antJUnit(libs.antJunit)
 }
 
-// Apply a specific Java toolchain to ease working on different environments.
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-}
-
 jacoco {
     toolVersion = "0.8.11"
 }


### PR DESCRIPTION
After #73, running `.\gradlew.bat build` on arm64 Windows would fail with "WindowsRegistry is not supported on this operating system." Removing the `java.toolchain` block from strcalc/build.gradle.kts allows it to succeed, as Gradle no longer tries to query the Windows registry to discover the Java toolchain. It will just pick up the toolchain from the environment.

Running `.\gradlew.bat -q javaToolchains` will still produce the failure, however.

See:
- https://docs.gradle.org/current/userguide/toolchains.html
- https://github.com/gradle/native-platform/issues/274#issuecomment-1029725490
- https://github.com/gradle/gradle/issues/21703