### PR TITLE
Replace Docker with TestTomcat in large tests

### DIFF
--- a/strcalc/src/test/java/com/mike_bland/training/testing/stringcalculator/ServletContractTest.java
+++ b/strcalc/src/test/java/com/mike_bland/training/testing/stringcalculator/ServletContractTest.java
@@ -99,7 +99,7 @@ class ServletContractTest {
     @MediumTest
     void servesLandingPage() throws Exception {
         var req = newRequestBuilder("/").GET().build();
-        tomcat.start();
+        tomcat.startWithBuildInputs();
 
         var resp = sendRequest(req);
 
@@ -244,7 +244,7 @@ class ServletContractTest {
     //   business logic.
     @MediumTest
     void productionImplementationTemporarilyReturnsError() throws Exception {
-        tomcat.start();
+        tomcat.startWithBuildInputs();
 
         var r = sendStringCalculatorRequest("");
 

--- a/strcalc/src/test/java/com/mike_bland/training/testing/utils/TestTomcat.java
+++ b/strcalc/src/test/java/com/mike_bland/training/testing/utils/TestTomcat.java
@@ -188,6 +188,10 @@ public class TestTomcat {
     private static void disableChecks(StandardContext ctx) {
         ctx.setClearReferencesThreadLocals(false);
         ctx.setClearReferencesRmiTargets(false);
+
+        // Prevent deleteBaseDir() failures on Windows, thanks to:
+        // - https://stackoverflow.com/a/20757153
+        ctx.setAntiResourceLocking(true);
     }
 
     public URI resolveEndpoint(String endpoint)
@@ -203,6 +207,7 @@ public class TestTomcat {
         if (!running) return;
         running = false;
         tomcat.stop();
+        tomcat.destroy();
         deleteBaseDir(this.baseDir);
     }
 

--- a/strcalc/src/test/java/com/mike_bland/training/testing/utils/TestTomcat.java
+++ b/strcalc/src/test/java/com/mike_bland/training/testing/utils/TestTomcat.java
@@ -15,13 +15,13 @@ import org.apache.catalina.webresources.DirResourceSet;
 import org.apache.catalina.webresources.StandardRoot;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.List;
-import java.util.function.Supplier;
 
 // Based on:
 // - https://www.infoworld.com/article/3510460/what-is-apache-tomcat-the-original-java-servlet-container.amp.html
@@ -41,6 +41,10 @@ public class TestTomcat {
     // Compiled classes packaged into the WAR file.
     public static final String WEB_INF_CLASSES =
             new File("build/classes/java/main").getAbsolutePath();
+
+    // Directory containing WAR files.
+    public static String WEB_APP_WAR_DIR =
+            new File("build/libs").getAbsolutePath();
 
     private final int port;
     private final String contextPath;
@@ -71,7 +75,7 @@ public class TestTomcat {
     //
     // The start(Servlet) variant does none of this, because it registers a
     // fully constructed Servlet directly from memory.
-    public void start() throws LifecycleException {
+    public void startWithBuildInputs() throws LifecycleException {
         startImpl(() -> {
             // Needed by CDI/Weld; avoids the following warning emitted during
             // TestTomcat.stop() (where the "/..." in "StandardContext[/...]" is
@@ -131,7 +135,35 @@ public class TestTomcat {
         });
     }
 
-    private synchronized void startImpl(Supplier<StandardContext> servletCtx)
+    // Starts Tomcat using the fully compiled WAR file.
+    public void startWithWarFile(String warFile)
+            throws LifecycleException, IOException {
+        final var warPath = new File(WEB_APP_WAR_DIR, warFile);
+        final var warUrl = warPath.toURI().toURL();
+
+        if (!warPath.exists()) {
+            throw new FileNotFoundException("WAR file not found: " + warPath);
+        }
+
+        startImpl(() -> {
+            // addWebapp will die with a FileNotFound error if this directory
+            // doesn't already exist.
+            final var baseDir = tomcat.getHost().getAppBaseFile();
+
+            if (!baseDir.exists() && !baseDir.mkdir()) {
+                final var m = "failed to create app dir for copied WAR file: ";
+                throw new IOException(m + baseDir);
+            }
+            tomcat.enableNaming();
+            return (StandardContext) tomcat.addWebapp(contextPath, warUrl);
+        });
+    }
+
+    private interface StandardContextProvider {
+        StandardContext get() throws LifecycleException, IOException;
+    }
+
+    private synchronized void startImpl(StandardContextProvider servletCtx)
             throws LifecycleException {
         if (running) return;
         running = true;
@@ -139,7 +171,12 @@ public class TestTomcat {
         tomcat.setBaseDir(this.baseDir.getAbsolutePath());
         tomcat.setPort(port);
         tomcat.setSilent(true);
-        disableChecks(servletCtx.get());
+
+        try {
+            disableChecks(servletCtx.get());
+        } catch (Exception e) {
+            throw new LifecycleException(e);
+        }
 
         // getConnector() is a recent requirement the other examples didn't use.
         // - https://stackoverflow.com/questions/15114892/embedded-tomcat-without-web-inf#comment98210881_15235711


### PR DESCRIPTION
With this change, the project now builds successfully on Windows.

With the embedded TestTomcat, there's no real need to use Docker for the large tests. This should also enable them to run on arm64 Windows, finally. It also makes the existing large test much faster, since there's no waiting for Docker to start and stop in the background.

However, I'm leaving the Docker-related testing utils in the repo for now. I may move them to another repo later, but I think it's handy code to have for reference.

---

Also, as it turns out, Windows will, by default, take a lock out on any file currently in use by a process. With the previous change, deleteBaseDir would fail to delete the Weld libs copied into the base dir.

Thanks to this Stack Overflow post, the fix turned out to be one StandardContext configuration setting:

- https://stackoverflow.com/a/20757153
- https://tomcat.apache.org/tomcat-10.1-doc/config/context.html#Standard_Implementation

Also added tomcat.destroy() to TestTomcat.stop(). I need to document these semantics, or update the interface to separate tomcat.{start,stop,destroy} from TestComcat.{start,stop).
